### PR TITLE
Xref split/download pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -190,7 +190,7 @@ sub resource_classes {
   return {
     %{$self->SUPER::resource_classes},
     'small'  => { 'LSF' => '-q production -M 200 -R "rusage[mem=200]"' }, # Change 'production' to 'production-rh74' if running on noah
-    'normal' => { 'LSF' => '-q production -M 500 -R "rusage[mem=500]"' }
+    'normal' => { 'LSF' => '-q production -M 1000 -R "rusage[mem=1000]"' }
   };
 }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -114,6 +114,7 @@ sub pipeline_analyses {
       -parameters      => {
         base_path    => $self->o('base_path'),
         clean_files  => $self->o('clean_files'),
+        skip_download => $self->o('skip_download'),
         clean_dir    => $self->o('clean_dir')
       },
       -rc_name    => 'small'
@@ -125,6 +126,7 @@ sub pipeline_analyses {
       -parameters      => {
         base_path    => $self->o('base_path'),
         clean_files  => $self->o('clean_files'),
+        skip_download => $self->o('skip_download'),
         clean_dir    => $self->o('clean_dir')
       },
       -rc_name    => 'small'

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -35,6 +35,7 @@ sub default_options {
     'work_dir'       => $self->o('ENV', 'HOME')."/work/lib",
     'sql_dir'          => $self->o('work_dir')."/ensembl/misc-scripts/xref_mapping",
     'release'          => $self->o('ensembl_release'),
+    'source_xref'      => '',
 
     # Parameters for source download
     'config_file'   => $self->o('work_dir')."/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json",
@@ -141,6 +142,7 @@ sub pipeline_analyses {
 	source_url    => $self->o('source_url'),
 	release       => $self->o('release'),
 	sql_dir       => $self->o('sql_dir'),
+	source_xref   => $self->o('source_xref')
       },
       -flow_into  => {
         '2->A' => 'pre_parse_source',
@@ -151,8 +153,9 @@ sub pipeline_analyses {
         {
       -logic_name => 'pre_parse_source',
       -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::PreParse',
-      -comment    => 'Store RefSeq data for faster species parsing',
-      -rc_name    => 'small'
+      -comment    => 'Store data for faster species parsing',
+      -rc_name    => '4GB',
+      -hive_capacity => 50,
     },
     {
       -logic_name => 'notify_by_email',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -155,11 +155,13 @@ sub pipeline_analyses {
 	source_url    => $self->o('source_url'),
 	release       => $self->o('release'),
 	sql_dir       => $self->o('sql_dir'),
-	source_xref   => $self->o('source_xref')
+	source_xref   => $self->o('source_xref'),
       },
       -flow_into  => {
-        '2->A' => 'pre_parse_source',
-        'A->1' => 'notify_by_email'
+        '1->A' => 'pre_parse_source',
+        '2' => 'pre_parse_source_dependent',
+	'3' => 'pre_parse_source_tertiary',
+	'A->1' => 'notify_by_email'
       },
       -rc_name    => 'small'
     },
@@ -167,8 +169,24 @@ sub pipeline_analyses {
       -logic_name => 'pre_parse_source',
       -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::PreParse',
       -comment    => 'Store data for faster species parsing',
-      -rc_name    => '4GB',
-      -hive_capacity => 50,
+      -rc_name    => '2GB',
+      -hive_capacity => 100,
+    },
+    {
+      -logic_name => 'pre_parse_source_dependent',
+      -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::PreParse',
+      -comment    => 'Store data for faster species parsing',
+      -rc_name    => '2GB',
+      -hive_capacity => 100,
+      -wait_for => 'pre_parse_source'
+    },
+    {
+      -logic_name => 'pre_parse_source_tertiary',
+      -module     => 'Bio::EnsEMBL::Production::Pipeline::Xrefs::PreParse',
+      -comment    => 'Store data for faster species parsing',
+      -rc_name    => '2GB',
+      -hive_capacity => 100,
+      -wait_for => 'pre_parse_source_dependent',
     },
     {
       -logic_name => 'notify_by_email',

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -142,6 +142,7 @@ sub pipeline_analyses {
       -parameters      => {
         base_path    => $self->o('base_path'),
         clean_files  => $self->o('clean_files'),
+	skip_download => $self->o('skip_download'),
         clean_dir    => $self->o('clean_dir')
       },
       -rc_name    => 'small'

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefDownload_conf.pm
@@ -158,10 +158,10 @@ sub pipeline_analyses {
 	source_xref   => $self->o('source_xref'),
       },
       -flow_into  => {
-        '1->A' => 'pre_parse_source',
+        '1' => 'pre_parse_source',
         '2' => 'pre_parse_source_dependent',
 	'3' => 'pre_parse_source_tertiary',
-	'A->1' => 'notify_by_email'
+	'-1' => 'notify_by_email'
       },
       -rc_name    => 'small'
     },
@@ -195,8 +195,10 @@ sub pipeline_analyses {
       -parameters => {
         email   => $self->o('email'),
         subject => 'Xref Download finished',
+	base_path => $self->o('base_path'),
         clean_files => $self->o('clean_files')
       },
+      -wait_for => 'pre_parse_source_tertiary',
       -rc_name    => 'small'
     }
   ];

--- a/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/PipeConfig/XrefProcess_conf.pm
@@ -39,6 +39,7 @@ sub default_options {
     # Parameters for source data
     'config_file'      => $self->o('work_dir')."/ensembl-production/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json",
     'source_url'       => '',
+    'source_xref'      => '',
 
     # Parameters for 'job_factory'
     'species'          => [],
@@ -93,8 +94,8 @@ sub pipeline_analyses {
       release    => $self->o('release'),
       sql_dir    => $self->o('sql_dir'),
       priority   => 1,
-      base_path  => $self->o('base_path'),
       source_url => $self->o('source_url'),
+      source_xref => $self->o('source_xref'),
       xref_url   => $self->o('xref_url'),
       xref_host  => $self->o('xref_host'),
       xref_port  => $self->o('xref_port'),
@@ -112,7 +113,6 @@ sub pipeline_analyses {
       release    => $self->o('release'),
       sql_dir    => $self->o('sql_dir'),
       priority   => 2,
-      base_path  => $self->o('base_path'),
       source_url => $self->o('source_url'),
       xref_url   => $self->o('xref_url'),
       xref_host  => $self->o('xref_host'),
@@ -133,7 +133,6 @@ sub pipeline_analyses {
       release    => $self->o('release'),
       sql_dir    => $self->o('sql_dir'),
       priority   => 3,
-      base_path  => $self->o('base_path'),
       source_url => $self->o('source_url'),
       xref_url   => $self->o('xref_url'),
       xref_host  => $self->o('xref_host'),
@@ -154,6 +153,9 @@ sub pipeline_analyses {
     -hive_capacity     => 300,
     -analysis_capacity => 50,
     -batch_size        => 30,
+    -parameters => {
+      source_xref => $self->o('source_xref'),
+    },
   },
   {
     -logic_name => 'dump_ensembl',
@@ -347,7 +349,7 @@ sub resource_classes {
   return {
     %{$self->SUPER::resource_classes},
     'small'  => { 'LSF' => '-q production -M 200 -R "rusage[mem=200]"' },
-    'normal' => { 'LSF' => '-q production -M 500 -R "rusage[mem=500]"' }
+    'normal' => { 'LSF' => '-q production -M 500 -R "rusage[mem=500]"' },
     'mem'    => { 'LSF' => '-q production -M 3000 -R "rusage[mem=3000]"' },
     'large'  => { 'LSF' => '-q production -M 10000 -R "rusage[mem=10000]"' },
   }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Base.pm
@@ -94,6 +94,9 @@ sub download_file {
   } elsif ($uri->scheme eq 'http' || $uri->scheme eq 'https') {
     $file_path = catfile($dest_dir, basename($uri->path));
     unless ($skip_download_if_file_present and -f $file_path) {
+      if (defined $db and $db eq 'checksum') {
+        $file_path = catfile($dest_dir, $source_name."-".basename($uri->path));
+      }
       open OUT, ">$file_path" or die "Couldn't open file $file_path $!";
       my $http = HTTP::Tiny->new();
       my $response = $http->get($uri->as_string());

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqDna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqDna.pm
@@ -40,6 +40,10 @@ sub run {
   if (!$clean_files) {return;}
   if ($name !~ /^RefSeq_dna/) {return;}
 
+  # Create needed directories
+  my $output_path = $clean_dir."/".$name;
+  make_path($output_path);
+
   # Save the clean files directory in source db
   my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
   my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
@@ -52,10 +56,6 @@ sub run {
 
   # Remove last '/' character if it exists
   if ($base_path =~ /\/$/) {chop($base_path);}
-
-  # Create needed directories
-  my $output_path = $clean_dir."/".$name;
-  make_path($output_path);
 
   # Get all files for source
   my $files_path = $base_path."/".$name;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqDna.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqDna.pm
@@ -88,18 +88,10 @@ sub run {
       # Remove unuused data
       my $skip_data = 0;
       while (<$in_fh>) {
-      	if ($_ =~ /^REFERENCE/) {
+      	if ($_ =~ /^REFERENCE/ || $_ =~ /^COMMENT/ || $_ =~ /^\s{5}exon/ || $_ =~ /^\s{5}misc_feature/ || $_ =~ /^\s{5}variation/) {
       	  $skip_data = 1;
-      	} elsif ($skip_data) {
-          if ($_ =~ /^\s{5}gene/) {
-            $skip_data = 0;
-          } elsif ($_ =~ /^ORIGIN/) {
-	          $skip_data = 0;
-          }
-      	} elsif ($_ =~ /^\s{5}exon/) {
-                $skip_data = 1;
-      	} elsif ($_ =~ /^\s{5}variation/){
-                $skip_data = 1;
+      	} elsif ($_ =~ /^\s{5}source/ || $_ =~ /^ORIGIN/) {
+          $skip_data = 0;
       	}
 
         if (!$skip_data) {print $out_fh $_;}

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqPeptide.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqPeptide.pm
@@ -34,10 +34,20 @@ sub run {
   my $version_file = $self->param('version_file');
   my $clean_files  = $self->param('clean_files');
   my $clean_dir    = $self->param_required('clean_dir');
+  my $skip_download = $self->param('skip_download');
 
   # Exit if not cleaning files or not a refseq source
   if (!$clean_files) {return;}
   if ($name !~ /^RefSeq_peptide/) {return;}
+
+  # Save the clean files directory in source db
+  my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
+  my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
+  my $update_version_sth = $dbi->prepare("UPDATE IGNORE version set clean_uri=? where source_id=(SELECT source_id FROM source WHERE name=?)");
+  $update_version_sth->execute($output_path, $name);
+  $update_version_sth->finish();
+  # If no new download, no need to clean up the files
+  if ($skip_download) { return; }
 
   # Remove last '/' character if it exists
   if ($base_path =~ /\/$/) {chop($base_path);}
@@ -93,12 +103,6 @@ sub run {
     }
   }
 
-  # Save the clean files directory in source db
-  my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
-  my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
-  my $update_version_sth = $dbi->prepare("UPDATE IGNORE version set clean_uri=? where source_id=(SELECT source_id FROM source WHERE name=?)");
-  $update_version_sth->execute($output_path, $name);
-  $update_version_sth->finish();
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqPeptide.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupRefseqPeptide.pm
@@ -40,6 +40,10 @@ sub run {
   if (!$clean_files) {return;}
   if ($name !~ /^RefSeq_peptide/) {return;}
 
+  # Create needed directories
+  my $output_path = $clean_dir."/".$name;
+  make_path($output_path);
+
   # Save the clean files directory in source db
   my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
   my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
@@ -51,10 +55,6 @@ sub run {
 
   # Remove last '/' character if it exists
   if ($base_path =~ /\/$/) {chop($base_path);}
-
-  # Create needed directories
-  my $output_path = $clean_dir."/".$name;
-  make_path($output_path);
 
   # Get all files for source
   my $files_path = $base_path."/".$name;
@@ -87,14 +87,11 @@ sub run {
       # Remove unused data
       my $skip_data = 0;
       while (<$in_fh>) {
-	      if ($_ =~ /^REFERENCE/) {
+        if ($_ =~ /^REFERENCE/ || $_ =~ /^COMMENT/ || $_ =~ /^\s{5}Protein/) {
           $skip_data = 1;
-        } elsif ($skip_data) {
-          if ($_ =~ /^\s{5}CDS/){
-            $skip_data = 0;
-          }
+        } elsif ($_ =~ /^\s{5}source/ || $_ =~ /^\s{5}CDS/) {
+          $skip_data = 0;
         }
-
         if (!$skip_data) {print $out_fh $_;}
       }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
@@ -41,6 +41,8 @@ sub run {
   if (!$clean_files) {return;}
   if ($name !~ /^Uniprot/) {return;}
 
+  my $file_size = 200000;
+
   # Remove last '/' character if it exists
   if ($base_path =~ /\/$/) {chop($base_path);}
 
@@ -97,12 +99,14 @@ sub run {
     }
 
     # Only start cleaning up if could get filehandle
+    my $count = 0;
+    my $file_count = 1;
     if (defined($in_fh)) {
       local $/ = "//\n";
 
-      $output_file = $output_path."/".$output_file;
-      open($out_fh, '>', $output_file)
-        or die "Couldn't open output file '$output_file' $!";
+      my $write_file = $output_path."/".$output_file . "-$file_count";
+      open($out_fh, '>', $write_file)
+        or die "Couldn't open output file '$write_file' $!";
 
       # Read full records
       while ($_ = $in_fh->getline()) {
@@ -114,6 +118,17 @@ sub run {
 
         # Added lines that we do need into output
         print $out_fh $_;
+
+	# Check how many lines have been processed and write to new file if size exceeded
+	$count++;
+	if ($count > $file_size) {
+          close($out_fh);
+	  $file_count++;
+	  $write_file = $output_path."/".$output_file . "-$file_count";
+	  open($out_fh, '>', $write_file)
+            or die "Couldn't open output file '$write_file' $!";
+          $count = 0;
+        }
       }
 
       close($in_fh);

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/CleanupUniprot.pm
@@ -71,6 +71,7 @@ sub run {
     # Skipped in parsing step
     'GO', 'UniGene', 'RGD', 'CCDS', 'IPI', 'UCSC', 'SGD', 'HGNC', 'MGI', 'VGNC', 'Orphanet',
     'ArrayExpress', 'GenomeRNAi', 'EPD', 'Xenbase', 'Reactome', 'MIM_GENE', 'MIM_MORBID', 'MIM',
+    'Interpro'
   );
   my $sources_to_remove = join("|", @source_names);
 
@@ -109,6 +110,7 @@ sub run {
         # Remove unused data
         $_ =~ s/R(N|P|X|A|T|R|L|C|G)\s{3}.*\n//g; # Remove references lines
         $_ =~ s/CC\s{3}.*\n//g; # Remove comments
+	$_ =~ s/FT\s{3}.*\n//g; # Remove feature coordinates
         $_ =~ s/DR\s{3}($sources_to_remove);.*\n//g; # Remove sources skipped at processing
 
         # Added lines that we do need into output

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/DownloadSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/DownloadSource.pm
@@ -35,6 +35,7 @@ sub run {
   my $skip_download    = $self->param_required('skip_download');
   my $db               = $self->param('db');
   my $version_file     = $self->param('version_file');
+  my $preparse         = $self->param('preparse');
 
   $self->dbc()->disconnect_if_idle() if defined $self->dbc();
 
@@ -47,9 +48,9 @@ sub run {
   my ($user, $pass, $host, $port, $source_db) = $self->parse_url($db_url);
   my $dbi = $self->get_dbi($host, $port, $user, $pass, $source_db);
   my $insert_source_sth = $dbi->prepare("INSERT IGNORE INTO source (name, parser) VALUES (?, ?)");
-  my $insert_version_sth = $dbi->prepare("INSERT ignore INTO version (source_id, uri, index_uri, count_seen, revision) VALUES ((SELECT source_id FROM source WHERE name = ?), ?, ?, ?, ?)");
+  my $insert_version_sth = $dbi->prepare("INSERT ignore INTO version (source_id, uri, index_uri, count_seen, revision, preparse) VALUES ((SELECT source_id FROM source WHERE name = ?), ?, ?, ?, ?, ?)");
   $insert_source_sth->execute($name, $parser);
-  $insert_version_sth->execute($name, $file_name, $db, $priority, $version);
+  $insert_version_sth->execute($name, $file_name, $db, $priority, $version, $preparse);
   $insert_source_sth->finish();
   $insert_version_sth->finish();
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ParseSource.pm
@@ -34,12 +34,14 @@ sub run {
   my $file_name    = $self->param_required('file_name');
   my $source_id    = $self->param_required('source');
   my $xref_url     = $self->param_required('xref_url');
+  my $source_xref  = $self->param_required('source_xref');
   my $db           = $self->param('db');
   my $release_file = $self->param('release_file');
 
   $self->dbc()->disconnect_if_idle() if defined $self->dbc();
 
   my ($user, $pass, $host, $port, $dbname) = $self->parse_url($xref_url);
+  my ($source_user, $source_pass, $source_host, $source_port, $source_dbname) = $self->parse_url($source_xref);
 
   my $xref_dbc = XrefParser::Database->new({
             host    => $host,
@@ -50,6 +52,7 @@ sub run {
   $xref_dbc->disconnect_if_idle();
 
   my $dbi = $self->get_dbi($host, $port, $user, $pass, $dbname);
+  my $source_dbi = $self->get_dbi($source_host, $source_port, $source_user, $source_pass, $source_dbname);
 
   my @files;
   push @files, $file_name;
@@ -68,6 +71,7 @@ sub run {
                              rel_file   => $release_file,
                              dbi        => $dbi,
                              species    => $species,
+			     xref_source=> $source_dbi,
                              file       => $file_name}) ;
     $self->cleanup_DBAdaptor($db);
   } else {
@@ -76,6 +80,7 @@ sub run {
                       species    => $species,
                       rel_file   => $release_file,
                       dbi        => $dbi,
+		      xref_source => $source_dbi,
                       files      => [@files] }) ;
   }
   if ($failure) { die; }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/BaseParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/BaseParser.pm
@@ -1,0 +1,1624 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::BaseParser;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Utils::Exception;
+use XrefParser::Database;
+use Carp;
+use DBI;
+use Getopt::Long;
+
+my $base_dir = File::Spec->curdir();
+
+my %xref_dependent_mapped;
+
+
+my $verbose;
+
+
+###################################################
+# Create new object.
+#   set global $verbose
+#   Store the dbi form the database for easy access
+###################################################
+sub new
+{
+  my ($proto, $database, $is_verbose) = @_;
+  my $dbh;
+  if(!defined $database){
+    croak 'No database specified';
+  } elsif ( $database->isa('XrefParser::Database') ) {
+    $dbh = $database->dbi;
+  } elsif ( $database->isa('DBI::db') ) {
+    $dbh = $database;
+  } else {
+    croak sprintf 'I do not recognise your %s class. It must be XrefParser::Database or a DBI $dbh instance'."\n",ref $database;
+  }
+  $verbose = $is_verbose;
+
+  my $class = ref $proto || $proto;
+  my $self =  bless {}, $class;
+  $self->dbi($dbh);
+  return $self;
+}
+
+
+##################################
+# Getter/Setter for the dbi object
+##################################
+sub dbi {
+  my ($self, $arg) = @_;
+
+  (defined $arg) &&
+    ($self->{_dbi} = $arg );
+  return $self->{_dbi};
+}
+
+
+#######################################################################
+# Given a file name, returns a IO::Handle object.  If the file is
+# gzipped, the handle will be to an unseekable stream coming out of a
+# zcat pipe.  If the given file name doesn't correspond to an existing
+# file, the routine will try to add '.gz' to the file name or to remove
+# any .'Z' or '.gz' and try again, printing a warning to stderr if the
+# alternative name does match an existing file.
+# Possible error states:
+#  - throws if no file name has been given, or if neither the provided
+#    name nor the alternative one points to an existing file
+#  - returns undef if an uncompressed file could not be opened for
+#    reading, or if the command 'zcat' is not in the search path
+#  - at least on Perl installations with multi-threading enabled,
+#    returns a VALID FILE HANDLE if zcat can be called but it cannot
+#    open the target file for reading - zcat will only report an error
+#    upon the first attempt to read from the handle
+#######################################################################
+sub get_filehandle
+{
+    my ($self, $file_name) = @_;
+
+    my $io =undef;
+
+    if(!(defined $file_name) or $file_name eq ''){
+      confess "No file name";
+    }
+    my $alt_file_name = $file_name;
+    $alt_file_name =~ s/\.(gz|Z)$//x;
+
+    if ( $alt_file_name eq $file_name ) {
+        $alt_file_name .= '.gz';
+    }
+
+    if ( !-e $file_name ) {
+        if ( ! -e $alt_file_name ) {
+            confess "Could not find either '$file_name' or '$alt_file_name'";
+        }
+        carp(   "File '$file_name' does not exist, "
+              . "will try '$alt_file_name'" );
+        $file_name = $alt_file_name;
+    }
+
+    if ( $file_name =~ /\.(gz|Z)$/x ) {
+        # Read from zcat pipe
+        $io = IO::File->new("zcat $file_name |")
+          or carp("Can not call 'zcat' to open file '$file_name'");
+    } else {
+        # Read file normally
+        $io = IO::File->new($file_name)
+          or carp("Can not open file '$file_name'");
+    }
+
+    if ( !defined $io ) { return }
+
+    if ($verbose) {
+      print "Reading from '$file_name'...\n" || croak 'Could not print out message';
+    }
+
+    return $io;
+}
+
+
+#############################################
+# Get source ID for a particular source name
+#
+# Arg[1] source name
+# Arg[2] priority description
+#
+# Returns source_id, or throws if not found
+#############################################
+sub get_source_id_for_source_name {
+  my ($self, $source_name,$priority_desc, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $low_name = lc $source_name;
+  my $sql = "SELECT source_id FROM source WHERE LOWER(name)='$low_name'";
+  if(defined $priority_desc){
+    $low_name = lc $priority_desc;
+    $sql .= " AND LOWER(priority_description)='$low_name'";
+    $source_name .= " ($priority_desc)";
+  }
+  my $sth = $dbi->prepare($sql);
+  $sth->execute();
+  my @row = $sth->fetchrow_array();
+  my $source_id;
+  if (@row) {
+    $source_id = $row[0];
+  } else {
+    my $msg = "No source_id for source_name='${source_name}'";
+    if ( defined $priority_desc ) {
+      $msg .= "priority_desc='${priority_desc}'";
+    }
+    confess $msg;
+  }
+  $sth->finish();
+  return $source_id;
+}
+
+
+
+############################################################
+# Get a set of source IDs matching a source name pattern
+#
+# Adds % to each end of the source name and doe a like query
+# to find all the matching source names source_ids.
+#
+# Returns an empty list if none found.
+############################################################
+sub get_source_ids_for_source_name_pattern {
+
+  my ($self, $source_name, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $big_name = uc $source_name;
+  my $sql = "SELECT source_id FROM source WHERE upper(name) LIKE '%${big_name}%'";
+
+  my $sth = $dbi->prepare($sql);
+  my @sources;
+  $sth->execute();
+  while(my @row = $sth->fetchrow_array()){
+    push @sources,$row[0];
+  }
+  $sth->finish;
+
+  return @sources;
+
+}
+
+
+###############################
+# From a source_id get the name
+###############################
+sub get_source_name_for_source_id {
+  my ($self, $source_id, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+  my $source_name;
+
+  my $sql = "SELECT name FROM source WHERE source_id= '$source_id'";
+  my $sth = $dbi->prepare($sql);
+  $sth->execute();
+  my @row = $sth->fetchrow_array();
+  if (@row) {
+    $source_name = $row[0];
+  } else {
+    carp "There is no entity with source-id  $source_id  in the source-table of the \n";
+    carp "xref-database. The source-id and the name of the source-id is hard-coded in populate_metadata.sql\n" ;
+    carp "and in the parser\n";
+    carp "Couldn't get source name for source ID $source_id\n";
+    $source_name = '-1';
+  }
+  $sth->finish;
+  return $source_name;
+}
+
+
+
+####################################################
+# Get a hash to go from accession of a dependent xref
+# to master_xref_id for all of source names given
+#####################################################
+sub get_valid_xrefs_for_dependencies{
+  my ($self, $dependent_name, $dbi, @reverse_ordered_source_list) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my %dependent_2_xref;
+
+  my $sql = 'select source_id from source where LOWER(name) =?';
+  my $sth = $dbi->prepare($sql);
+  my @dependent_sources;
+  $sth->execute(lc $dependent_name);
+  while(my @row = $sth->fetchrow_array()){
+   push @dependent_sources,$row[0];
+  }
+
+  my @sources;
+  foreach my $name (@reverse_ordered_source_list){
+    $sth->execute(lc $name);
+    while(my @row = $sth->fetchrow_array()){
+      push @sources,$row[0];
+    }
+  }
+  $sth->finish;
+
+  my $dep_sql = (<<'DSS');
+  SELECT d.master_xref_id, x2.accession
+    FROM dependent_xref d, xref x1, xref x2
+      WHERE x1.xref_id = d.master_xref_id AND
+            x1.source_id = ? AND
+            x2.xref_id = d.dependent_xref_id AND
+            x2.source_id = ?
+DSS
+
+  $sth = $dbi->prepare($dep_sql);
+  foreach my $d (@dependent_sources){
+    foreach my $s (@sources){
+       $sth->execute($s,$d);
+       while(my @row = $sth->fetchrow_array()){
+	 $dependent_2_xref{$row[1]} = $row[0];
+       }
+     }
+  }
+  $sth->finish;
+  return \%dependent_2_xref;
+}
+
+
+
+####################################################
+# Get a hash to go from accession of a direct xref
+# to master_xref_id for all of source names given
+#####################################################
+sub get_valid_xrefs_for_direct_xrefs{
+  my ($self, $direct_name, $separator, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my %direct_2_xref;
+
+  my $sql = 'select source_id from source where name like ?';
+  my $sth = $dbi->prepare($sql);
+  my @direct_sources;
+  $sth->execute("${direct_name}%");
+  while(my @row = $sth->fetchrow_array()){
+    push @direct_sources,$row[0];
+  }
+  $sth->finish;
+
+  my $gen_sql =(<<"GDS");
+SELECT d.general_xref_id, d.ensembl_stable_id, 'TYPE', d.linkage_xref, x1.accession
+  FROM TABLE_direct_xref d, xref x1
+    WHERE x1.xref_id = d.general_xref_id AND
+          x1.source_id=?
+GDS
+
+  my @sth;
+  my $i=0;
+  foreach my $type (qw(Gene Transcript Translation)){
+    my $t_sql = $gen_sql;
+    my $table = lc $type;
+    $t_sql =~ s/TABLE/$table/xsm;
+    $t_sql =~ s/TYPE/$type/xsm;
+
+    $sth[$i++] = $dbi->prepare($t_sql);
+  }
+
+  foreach my $d (@direct_sources){
+    for my $ii (0..2) {
+      $sth[$ii]->execute($d);
+      while(my ($gen_xref_id, $stable_id, $type, $link, $acc) = $sth[$ii]->fetchrow_array()){
+	$direct_2_xref{$acc} = $gen_xref_id.$separator.$stable_id.$separator.$type.$separator.$link;
+      }
+      $sth[$ii]->finish();
+    }
+  }
+
+  return \%direct_2_xref;
+}
+
+
+#############################################
+# Get a hash of label to acc for a particular
+# source name and species_id
+#############################################
+sub label_to_acc{
+
+  my ($self,$source_name,$species_id, $dbi) =@_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  # First cache synonyms so we can quickly add them later
+  my %synonyms;
+  my $syn_sth = $dbi->prepare('SELECT xref_id, synonym FROM synonym');
+  $syn_sth->execute();
+
+  my ($xref_id, $synonym);
+  $syn_sth->bind_columns(\$xref_id, \$synonym);
+  while ($syn_sth->fetch()) {
+
+    push @{$synonyms{$xref_id}}, $synonym;
+
+  }
+  $syn_sth->finish;
+
+  my %valid_codes;
+  my @sources;
+
+  my $big_name = uc $source_name;
+  my $sql = "select source_id from source where upper(name) like '%${big_name}%'";
+  my $sth = $dbi->prepare($sql);
+  $sth->execute();
+  while(my @row = $sth->fetchrow_array()){
+    push @sources,$row[0];
+  }
+  $sth->finish;
+
+  foreach my $source (@sources){
+    $sql = "select label, xref_id from xref where species_id = $species_id and source_id = $source";
+    $sth = $dbi->prepare($sql);
+    $sth->execute();
+    while(my @row = $sth->fetchrow_array()){
+      $valid_codes{$row[0]} =$row[1];
+      # add any synonyms for this xref as well
+      foreach my $syn (@{$synonyms{$row[1]}}) {
+	$valid_codes{$syn} = $row[1];
+      }
+    }
+  }
+  $sth->finish;
+  return \%valid_codes;
+}
+
+
+####################################################
+# get_valid_codes
+#
+# hash of accessions to array of xref dbIDs.
+# This is an array becouse more than one entry can
+# exist. i.e. for uniprot and refseq we have direct
+# and sequence match sets and we need to give both.
+#
+# This list is a cache of acceptable IDs in order to
+# reduce querying when attaching external accessions
+# to xrefs.
+####################################################
+sub get_valid_codes{
+
+  my ($self,$source_name,$species_id, $dbi) =@_;
+
+  my %valid_codes;
+  my @sources;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $big_name = uc $source_name;
+  my $sql = "select source_id from source where upper(name) like '%$big_name%'";
+  my $sth = $dbi->prepare($sql);
+  $sth->execute();
+  while(my @row = $sth->fetchrow_array()){
+    push @sources,$row[0];
+  }
+  $sth->finish;
+
+  foreach my $source (@sources){
+    $sql = "select accession, xref_id from xref where species_id = $species_id and source_id = $source";
+    $sth = $dbi->prepare($sql);
+    $sth->execute();
+    while(my @row = $sth->fetchrow_array()){
+      push @{$valid_codes{$row[0]}}, $row[1];
+    }
+  }
+  $sth->finish();
+  return \%valid_codes;
+}
+
+##############################
+# Upload xrefs to the database
+##############################
+sub upload_xref_object_graphs {
+  my ($self, $rxrefs, $dbi) = @_;
+
+  my $count = scalar @{$rxrefs};
+  if($verbose) {
+    print "count = $count\n" || croak 'Could not print out count';
+  }
+
+  if ($count) {
+
+    #################
+    # upload new ones
+    ##################
+    if ($verbose) {
+      print "Uploading xrefs\n"
+	|| croak 'Could not print string';
+    }
+
+
+    #################################################################################
+    # Start of sql needed to add xrefs, primary_xrefs, synonym, dependent_xrefs etc..
+    #################################################################################
+    $dbi = $self->dbi unless defined $dbi;
+    my $xref_sth = $dbi->prepare('INSERT INTO xref (accession,version,label,description,source_id,species_id, info_type) VALUES(?,?,?,?,?,?,?)');
+    my $pri_insert_sth = $dbi->prepare('INSERT INTO primary_xref VALUES(?,?,?,?)');
+    my $pri_update_sth = $dbi->prepare('UPDATE primary_xref SET sequence=? WHERE xref_id=?');
+    my $syn_sth = $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
+    my $xref_update_label_sth = $dbi->prepare('UPDATE xref SET label=? WHERE xref_id=?');
+    my $xref_update_descr_sth = $dbi->prepare('UPDATE xref SET description=? WHERE xref_id=?');
+    my $pair_sth = $dbi->prepare('INSERT INTO pairs VALUES(?,?,?)');
+    my $xref_id_sth = $dbi->prepare("SELECT xref_id FROM xref WHERE accession = ? AND source_id = ? AND species_id = ?");
+    my $primary_xref_id_sth = $dbi->prepare('SELECT xref_id FROM primary_xref WHERE xref_id=?');
+
+
+
+    # disable error handling here as we'll do it ourselves
+    # reenabled it, as errorcodes are really unhelpful
+    $xref_sth->{RaiseError} = 0;
+    $xref_sth->{PrintError} = 0;
+
+    #################################################################################
+    # End of sql needed to add xrefs, primary_xrefs, synonym, dependent_xrefs etc..
+    #################################################################################
+
+
+    foreach my $xref (@{$rxrefs}) {
+       my ($xref_id, $direct_xref_id);
+       if(!(defined $xref->{ACCESSION} )){
+	 print "Your xref does not have an accession-number,so it can't be stored in the database\n"
+	   || croak 'Could not write message';
+	 return;
+       }
+
+       ########################################
+       # Create entry in xref table and note ID
+       ########################################
+       if(! $xref_sth->execute($xref->{ACCESSION},
+			 $xref->{VERSION} || 0,
+			 $xref->{LABEL}|| $xref->{ACCESSION},
+			 $xref->{DESCRIPTION},
+			 $xref->{SOURCE_ID},
+			 $xref->{SPECIES_ID},
+			 $xref->{INFO_TYPE} || 'MISC')){
+	 #
+	 #  if we failed to add the xref it must already exist so go find the xref_id for this
+	 #
+	 if(!(defined $xref->{SOURCE_ID})){
+	   print "your xref: $xref->{ACCESSION} does not have a source-id\n";
+	   return;
+	 }
+         $xref_id_sth->execute(
+                   $xref->{ACCESSION},
+                   $xref->{SOURCE_ID},
+                   $xref->{SPECIES_ID} );
+         $xref_id = ($xref_id_sth->fetchrow_array())[0];
+	 if(defined $xref->{LABEL} ) {
+	   $xref_update_label_sth->execute($xref->{LABEL},$xref_id) ;
+	 }
+	 if(defined $xref->{DESCRIPTION} ){
+	   $xref_update_descr_sth->execute($xref->{DESCRIPTION},$xref_id);
+	 }
+       }
+       else{
+         $xref_id_sth->execute(
+                   $xref->{ACCESSION},
+                   $xref->{SOURCE_ID},
+                   $xref->{SPECIES_ID} );
+         $xref_id = ($xref_id_sth->fetchrow_array())[0];
+       }
+
+       foreach my $direct_xref (@{$xref->{DIRECT_XREFS}}) {
+         $xref_sth->execute( $xref->{ACCESSION},
+                             $xref->{VERSION} || 0,
+                             $xref->{LABEL} || $xref->{ACCESSION},
+                             $xref->{DESCRIPTION},
+                             $direct_xref->{SOURCE_ID},
+                             $xref->{SPECIES_ID},
+                             $direct_xref->{LINKAGE_TYPE});
+         $xref_id_sth->execute(
+                   $xref->{ACCESSION},
+                   $direct_xref->{SOURCE_ID},
+                   $xref->{SPECIES_ID} );
+         $direct_xref_id = ($xref_id_sth->fetchrow_array())[0];
+         $self->add_direct_xref($direct_xref_id, $direct_xref->{STABLE_ID}, $direct_xref->{ENSEMBL_TYPE},$direct_xref->{LINKAGE_TYPE}, $dbi);
+       }
+
+       ################
+       # Error checking
+       ################
+       if(!((defined $xref_id) and $xref_id)){
+	 print STDERR "xref_id is not set for :\n".
+	   "$xref->{ACCESSION}\n$xref->{LABEL}\n".
+	     "$xref->{DESCRIPTION}\n$xref->{SOURCE_ID}\n".
+	       "$xref->{SPECIES_ID}\n";
+       }
+
+
+       #############################################################################
+       # create entry in primary_xref table with sequence; if this is a "cumulative"
+       # entry it may already exist, and require an UPDATE rather than an INSERT
+       #############################################################################
+       if(defined $xref->{SEQUENCE} ){
+         $primary_xref_id_sth->execute($xref_id) or croak( $dbi->errstr() );
+         my @row = $primary_xref_id_sth->fetchrow_array();
+         my $exists = $row[0];
+	 if ( $exists ) {
+	   $pri_update_sth->execute( $xref->{SEQUENCE}, $xref_id )
+	     or croak( $dbi->errstr() );
+	 } else {
+	   $pri_insert_sth->execute( $xref_id, $xref->{SEQUENCE},
+				     $xref->{SEQUENCE_TYPE},
+				     $xref->{STATUS} )
+	     or croak( $dbi->errstr() );
+	 }
+       }
+
+       ##########################################################
+       # if there are synonyms, add entries in the synonym table
+       ##########################################################
+       foreach my $syn ( @{ $xref->{SYNONYMS} } ) {
+	 $syn_sth->execute( $xref_id, $syn )
+	   or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
+       }
+
+       #######################################################################
+       # if there are dependent xrefs, add xrefs and dependent xrefs for them
+       #######################################################################
+     DEPENDENT_XREF:
+       foreach my $depref (@{$xref->{DEPENDENT_XREFS}}) {
+         my %dep = %{$depref};
+
+         #####################################
+         # Insert the xref and get its xref_id
+         #####################################
+         # print "inserting $dep{ACCESSION},$dep{VERSION},$dep{LABEL},$dep{DESCRIPTION},$dep{SOURCE_ID},${\$xref->{SPECIES_ID}}\n";
+         my $dep_xref_id = $self->add_xref({
+                                            'acc'        => $dep{ACCESSION},
+                                            'source_id'  => $dep{SOURCE_ID},
+                                            'species_id' => $xref->{SPECIES_ID},
+                                            'label'      => $dep{LABEL},
+                                            'desc'       => $dep{DESCRIPTION},
+                                            'version'    => $dep{VERSION},
+                                            'info_type'  => 'DEPENDENT',
+                                            'dbi'        => $dbi,
+                                          });
+         if( ! $dep_xref_id ) {
+           next DEPENDENT_XREF;
+         }
+
+         #
+         # Add the linkage_annotation and source id it came from
+         #
+         $self->add_dependent_xref_maponly( $dep_xref_id,
+                                            $dep{LINKAGE_SOURCE_ID},
+                                            $xref_id,
+                                            $dep{LINKAGE_ANNOTATION});
+
+         #########################################################
+         # if there are synonyms, add entries in the synonym table
+         #########################################################
+         foreach my $syn ( @{ $dep{SYNONYMS} } ) {
+           $syn_sth->execute( $dep_xref_id, $syn )
+             or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
+         } # foreach syn
+
+       } # foreach dep
+
+       #################################################
+       # Add the pair data. refseq dna/pep pairs usually
+       #################################################
+       if(defined $xref_id and defined $xref->{PAIR} ){
+	 $pair_sth->execute($xref->{SOURCE_ID},$xref->{ACCESSION},$xref->{PAIR});
+       }
+
+
+       ###########################
+       # tidy up statement handles
+       ###########################
+       if(defined $xref_sth) {$xref_sth->finish()};
+       if(defined $pri_insert_sth) {$pri_insert_sth->finish()} ;
+       if(defined $pri_update_sth) {$pri_update_sth->finish()};
+       if(defined $syn_sth) { $syn_sth->finish()};
+       if(defined $xref_update_label_sth) { $xref_update_label_sth->finish()};
+       if(defined $xref_update_descr_sth) { $xref_update_descr_sth->finish()};
+       if(defined $pair_sth) { $pair_sth->finish()};
+       if(defined $xref_id_sth) { $xref_id_sth->finish()};
+       if(defined $primary_xref_id_sth) { $primary_xref_id_sth->finish()};
+
+     }  # foreach xref
+
+  }
+  return 1;
+}
+
+######################################################################################
+# Add direct xref to the table XXX_direct_xref. (XXX -> Gene.Transcript or Translation
+# Xref has to exist already, this module just adds ot yo the direct_xref table.
+# $direct_xref is a reference to an array of hash objects.
+######################################################################################
+sub upload_direct_xrefs{
+  my ($self, $direct_xref, $dbi)  = @_;
+  $dbi = $self->dbi unless defined $dbi;
+  for my $dr(@{$direct_xref}) {
+
+    ################################################
+    # Find the xref_id for this accession and source
+    ################################################
+    my $general_xref_id = $self->get_xref($dr->{ACCESSION},$dr->{SOURCE_ID},$dr->{SPECIES_ID}, $dbi);
+
+    #######################################################
+    # If found add the direct xref else write error message
+    #######################################################
+    if ($general_xref_id){
+      $self->add_direct_xref($general_xref_id, $dr->{ENSEMBL_STABLE_ID},$dr->{ENSEMBL_TYPE},$dr->{LINKAGE_XREF}, $dbi);
+    }
+    else{
+      print {*STDERR} 'Problem Could not find accession '.$dr->{ACCESSION}.' for source '.$dr->{SOURCE}.
+	' so not able to add direct xref to '.$dr->{ENSEMBL_STABLE_ID}."\n";
+    }
+  }
+  return;
+}
+
+
+
+
+###############################################
+# Insert into the meta table the key and value.
+###############################################
+sub add_meta_pair {
+
+  my ($self, $key, $value, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sth = $dbi->prepare('insert into meta (meta_key, meta_value, date) values("'.$key.'", "'.$value.'", now())');
+  $sth->execute;
+  $sth->finish;
+  return;
+}
+
+
+
+#################################################
+# Create a hash of all the source names for xrefs
+#################################################
+sub get_xref_sources {
+
+  my $self = shift;
+  my $dbi = shift;
+  $dbi = $self->dbi unless defined $dbi;
+  my %sourcename_to_sourceid;
+
+  my $sth = $dbi->prepare('SELECT name,source_id FROM source');
+  $sth->execute() or croak( $dbi->errstr() );
+  while(my @row = $sth->fetchrow_array()) {
+    my $source_name = $row[0];
+    my $source_id = $row[1];
+    $sourcename_to_sourceid{$source_name} = $source_id;
+  }
+  $sth->finish;
+
+  return %sourcename_to_sourceid;
+}
+
+########################################################################
+# Create and return a hash that that goes from species_id to taxonomy_id
+########################################################################
+sub species_id2taxonomy {
+
+  my $self = shift;
+  my $dbi = shift;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my %species_id2taxonomy;
+
+  my $sth = $dbi->prepare('SELECT species_id, taxonomy_id FROM species');
+  $sth->execute() or croak( $dbi->errstr() );
+  while(my @row = $sth->fetchrow_array()) {
+    my $species_id = $row[0];
+    my $taxonomy_id = $row[1];
+    if(defined $species_id2taxonomy{$species_id} ){
+      push @{$species_id2taxonomy{$species_id}}, $taxonomy_id;
+    }
+    else{
+      $species_id2taxonomy{$species_id} = [$taxonomy_id];
+    }
+  }
+  $sth->finish();
+  return %species_id2taxonomy;
+}
+
+
+
+#########################################################################
+# Create and return a hash that that goes from species_id to species name
+#########################################################################
+sub species_id2name {
+  my $self = shift;
+  my $dbi = shift;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my %species_id2name;
+
+  my $sth = $dbi->prepare('SELECT species_id, name FROM species');
+  $sth->execute() or croak( $dbi->errstr() );
+  while ( my @row = $sth->fetchrow_array() ) {
+    my $species_id = $row[0];
+    my $name       = $row[1];
+    $species_id2name{$species_id} = [ $name ];
+  }
+  $sth->finish();
+
+  ##############################################
+  # Also populate the hash with all the aliases.
+  ##############################################
+  $sth = $dbi->prepare('SELECT species_id, aliases FROM species');
+  $sth->execute() or croak( $dbi->errstr() );
+  while ( my @row = $sth->fetchrow_array() ) {
+    my $species_id = $row[0];
+    foreach my $name ( split /,\s*/xms, $row[1] ) {
+      $species_id2name{$species_id} ||= [];
+      push @{$species_id2name{$species_id}}, $name;
+    }
+  }
+  $sth->finish();
+
+  return %species_id2name;
+} ## end sub species_id2name
+
+
+###########################################################################
+# If there was an error, an xref with the same acc & source already exists.
+# If so, find its ID, otherwise get ID of xref just inserted
+###########################################################################
+sub get_xref_id {
+  my ($self, $arg_ref) = @_;
+  my $sth     = $arg_ref->{sth}        || croak 'Need a statement handle for get_xref_id';
+  my $acc     = $arg_ref->{acc}        || croak 'Need an accession for get_xref_id';
+  my $source  = $arg_ref->{source_id}  || croak 'Need an source_id for get_xref_id';
+  my $species = $arg_ref->{species_id} || confess 'Need an species_id for get_xref_id';
+  my $error   = $arg_ref->{error};
+  my $dbi     = $arg_ref->{dbi};
+
+  my $id = $self->get_xref($acc, $source, $species, $dbi);
+
+  return $id;
+}
+
+##################################################################
+# If primary xref already exists for a partiuclar xref_id return 1
+# else return 0;
+##################################################################
+sub primary_xref_id_exists {
+
+  my ($self, $xref_id, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $exists = 0;
+
+  my $sth = $dbi->prepare('SELECT xref_id FROM primary_xref WHERE xref_id=?');
+  $sth->execute($xref_id) or croak( $dbi->errstr() );
+  my @row = $sth->fetchrow_array();
+  my $result = $row[0];
+  if (defined $result) {$exists = 1; }
+  $sth->finish();
+
+  return $exists;
+
+}
+
+############################################
+# Get the tax id for a particular species id
+############################################
+sub get_taxonomy_from_species_id{
+  my ($self,$species_id, $dbi) = @_;
+  my %hash;
+
+  $dbi = $self->dbi unless defined $dbi;
+  my $sth = $dbi->prepare("SELECT taxonomy_id FROM species WHERE species_id = $species_id");
+  $sth->execute() or croak( $dbi->errstr() );
+  while(my @row = $sth->fetchrow_array()) {
+    $hash{$row[0]} = 1;
+  }
+  $sth->finish;
+  return \%hash;
+}
+
+
+#################################################
+# xref_ids for a given stable id and linkage_xref
+#################################################
+sub get_direct_xref{
+ my ($self,$stable_id,$type,$link, $dbi) = @_;
+ $dbi = $self->dbi unless defined $dbi;
+
+ $type = lc $type;
+
+ my $sql = "select general_xref_id from ${type}_direct_xref d where ensembl_stable_id = ? and linkage_xref ";
+ my @sql_params = ( $stable_id );
+ if ( defined $link ) {
+   $sql .= '= ?';
+   push @sql_params, $link;
+ }
+ else {
+   $sql .= 'is null';
+ }
+ my  $direct_sth = $dbi->prepare($sql);
+
+ $direct_sth->execute( @sql_params ) || croak( $dbi->errstr() );
+ if ( wantarray () ) {
+   # Generic behaviour
+
+   my @results;
+
+   my $all_rows = $direct_sth->fetchall_arrayref();
+   foreach my $row_ref ( @{ $all_rows } ) {
+     push @results, $row_ref->[0];
+   }
+
+   return @results;
+ }
+ else {
+   # Backwards-compatible behaviour. FIXME: can we get rid of it?
+   # There seem to be no parsers present relying on the old behaviour
+   # any more
+   if ( my @row = $direct_sth->fetchrow_array() ) {
+     return $row[0];
+   }
+ }
+ $direct_sth->finish();
+ return;
+}
+
+
+###################################################################
+# return the xref_id for a particular accession, source and species
+# if not found return undef;
+###################################################################
+sub get_xref{
+  my ($self,$acc,$source, $species_id, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  #
+  # If the statement handle does nt exist create it.
+  #
+  my $sql = 'select xref_id from xref where accession = ? and source_id = ? and species_id = ?';
+  my $get_xref_sth = $dbi->prepare($sql);
+
+  #
+  # Find the xref_id using the sql above
+  #
+  $get_xref_sth->execute( $acc, $source, $species_id ) or croak( $dbi->errstr() );
+  if(my @row = $get_xref_sth->fetchrow_array()) {
+    return $row[0];
+  }
+  $get_xref_sth->finish();
+  return;
+}
+
+###################################################################
+# return the object_xref_id for a particular xref_id, ensembl_id and ensembl_object_type
+# if not found return undef;
+###################################################################
+sub get_object_xref {
+  my ($self, $xref_id, $ensembl_id, $object_type, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sql = 'select object_xref_id from object_xref where xref_id = ? and ensembl_object_type = ? and ensembl_id = ?';
+  my $get_object_xref_sth = $dbi->prepare($sql);
+
+  #
+  # Find the object_xref_id using the sql above
+  #
+  $get_object_xref_sth->execute( $xref_id, $ensembl_id, $object_type) or croak( $dbi->errstr() );
+  if(my @row = $get_object_xref_sth->fetchrow_array()) {
+    return $row[0];
+  }
+  $get_object_xref_sth->finish();
+  return;
+}
+
+
+###########################################################
+# Create an xref..
+# If it already exists it return that xrefs xref_id
+# else creates it and return the new xre_id
+###########################################################
+sub add_xref {
+  my ( $self, $arg_ref) = @_;
+
+  my $acc         = $arg_ref->{acc}        || croak 'add_xref needs aa acc';
+  my $source_id   = $arg_ref->{source_id}  || croak 'add_xref needs a source_id';
+  my $species_id  = $arg_ref->{species_id} || croak 'add_xref needs a species_id';
+  my $label       = $arg_ref->{label}      // $acc;
+  my $description = $arg_ref->{desc};
+  my $version     = $arg_ref->{version}    // 0;
+  my $info_type   = $arg_ref->{info_type}  // 'MISC';
+  my $info_text   = $arg_ref->{info_text}  // q{};
+  my $dbi         = $arg_ref->{dbi};
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  ##################################################################
+  # See if it already exists. It so return the xref_id for this one.
+  ##################################################################
+  my $xref_id = $self->get_xref($acc,$source_id, $species_id, $dbi);
+  if(defined $xref_id){
+    return $xref_id;
+  }
+
+  my $add_xref_sth =
+      $dbi->prepare( 'INSERT INTO xref '
+         . '(accession,version,label,description,source_id,species_id, info_type, info_text) '
+         . 'VALUES(?,?,?,?,?,?,?,?)' );
+
+  ######################################################################
+  # If the description is more than 255 characters, chop it off and add
+  # an indication that it has been truncated to the end of it.
+  ######################################################################
+  if (defined $description && ((length $description) > 255 ) ) {
+    my $truncmsg = ' /.../';
+    substr $description, 255 - (length $truncmsg),
+            length $truncmsg, $truncmsg;
+  }
+
+
+  ####################################
+  # Add the xref and croak if it fails
+  ####################################
+  $add_xref_sth->execute( $acc, $version || 0, $label,
+                          $description, $source_id, $species_id, $info_type, $info_text
+  ) or croak("$acc\t$label\t\t$source_id\t$species_id\n");
+
+  $add_xref_sth->finish();
+  return $add_xref_sth->{'mysql_insertid'};
+} ## end sub add_xref
+
+
+###########################################################
+# Create an object_xref..
+# If it already exists it return the object_xref_id
+# else creates it and returns the new object_xref_id
+###########################################################
+
+sub add_object_xref {
+  my ($self, $arg_ref) = @_;
+
+  my $xref_id     = $arg_ref->{xref_id}     || croak 'add_object_xref needs an xref_id';
+  my $ensembl_id  = $arg_ref->{ensembl_id}  || croak 'add_object_xref needs a ensembl_id';
+  my $object_type = $arg_ref->{object_type} || croak 'add_object_xref needs an object_type';
+  my $dbi         = $arg_ref->{dbi};
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  ##################################################################
+  # See if it already exists. It so return the xref_id for this one.
+  ##################################################################
+
+  my $object_xref_id = $self->get_object_xref($xref_id, $ensembl_id, $object_type, $dbi);
+  if(defined $object_xref_id){
+    return $object_xref_id;
+  }
+
+  my $add_object_xref_sth =
+      $dbi->prepare( 'INSERT INTO object_xref'
+         . '(ensembl_id, ensembl_object_type, xref_id) '
+         . 'VALUES(?,?,?)' );
+
+  ####################################
+  # Add the object_xref and croak if it fails
+  ####################################
+  $add_object_xref_sth->execute($ensembl_id, $object_type, $xref_id
+  ) or croak("$ensembl_id\t$object_type\t\t$xref_id\n");
+
+  $add_object_xref_sth->finish();
+  return $add_object_xref_sth->{'mysql_insertid'};
+}
+
+###########################################################
+# Create an identity_xref
+###########################################################
+
+sub add_identity_xref {
+  my ($self, $arg_ref) = @_;
+
+  my $object_xref_id  = $arg_ref->{object_xref_id}  || croak 'add_identity_xref needs an object_xref_id';
+  my $score           = $arg_ref->{score}           || croak 'add_identity_xref needs a score';
+  my $target_identity = $arg_ref->{target_identity} || croak 'add_identity_xref needs a target_identity';
+  my $query_identity  = $arg_ref->{query_identity}  || croak 'add_identity_xref needs a query_identity';
+  my $dbi             = $arg_ref->{dbi};
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $add_identity_xref_sth =
+      $dbi->prepare( 'INSERT INTO identity_xref'
+         . '(object_xref_id, score, query_identity, target_identity) '
+         . 'VALUES(?,?,?,?)' );
+
+  ####################################
+  # Add the object_xref and croak if it fails
+  ####################################
+  $add_identity_xref_sth->execute($object_xref_id, $score, $query_identity, $target_identity
+  ) or croak("$object_xref_id\t$score\t\t$query_identity\t$target_identity\n");
+  $add_identity_xref_sth->finish();
+  return;
+}
+
+
+###################################################################
+# Create new xref if needed and add as a direct xref to a stable_id
+# Note that a corresponding method for dependent xrefs is called add_dependent_xref()
+###################################################################
+sub add_to_direct_xrefs{
+  my ($self, $arg_ref) = @_;
+
+  my $stable_id   = $arg_ref->{stable_id}   || croak ('Need a direct_xref on which this xref linked too' );
+  my $type        = $arg_ref->{type}        || croak ('Need a table type on which to add');
+  my $acc         = $arg_ref->{acc}         || croak ('Need an accession of this direct xref' );
+  my $source_id   = $arg_ref->{source_id}   || croak ('Need a source_id for this direct xref' );
+  my $species_id  = $arg_ref->{species_id}  || croak ('Need a species_id for this direct xref' );
+  my $version     = $arg_ref->{version}     // 0;
+  my $label       = $arg_ref->{label}       // $acc;
+  my $description = $arg_ref->{desc};
+  my $linkage     = $arg_ref->{linkage};
+  my $info_text   = $arg_ref->{info_text}   // q{};
+  my $dbi         = $arg_ref->{dbi};
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sql = (<<'AXX');
+  INSERT INTO xref (accession,version,label,description,source_id,species_id, info_type, info_text)
+          VALUES (?,?,?,?,?,?,?,?)
+AXX
+  my $add_xref_sth = $dbi->prepare($sql);
+
+  ###############################################################
+  # If the acc already has an xrefs find it else cretae a new one
+  ###############################################################
+  my $direct_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
+  if(!(defined $direct_id)){
+    $add_xref_sth->execute(
+        $acc, $version || 0, $label,
+        $description, $source_id, $species_id, 'DIRECT', $info_text
+    ) or croak("$acc\t$label\t\t$source_id\t$species_id\n");
+  }
+  $add_xref_sth->finish();
+
+  $direct_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
+
+  #########################
+  # Now add the direct info
+  #########################
+  $self->add_direct_xref($direct_id, $stable_id, $type, $linkage, $dbi);
+  return;
+}
+
+
+##################################################################
+# Add a single record to the direct_xref table.
+# Note that an xref must already have been added to the xref table
+# Note that a corresponding method for dependent xrefs is called add_dependent_xref_maponly()
+##################################################################
+sub add_direct_xref {
+  my ($self, $general_xref_id, $ensembl_stable_id, $ensembl_type, $linkage_type, $dbi, $update_info_type) = @_;
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  # Check if such a mapping exists yet. Make sure get_direct_xref() is
+  # invoked in list context, otherwise it will fall back to legacy
+  # behaviour of returning a single xref_id even when multiple ones
+  # match.
+  # Note: get_direct_xref() does not currently cache its output,
+  # consider changing this should performance become an issue
+  my @existing_xref_ids = $self->get_direct_xref($ensembl_stable_id,
+                                                 $ensembl_type,
+                                                 $linkage_type,
+                                                 $dbi);
+  if ( scalar grep { $_ == $general_xref_id } @existing_xref_ids ) {
+    return;
+  }
+
+  $ensembl_type = lc($ensembl_type);
+  my $sql = "INSERT INTO " . $ensembl_type . "_direct_xref VALUES (?,?,?)";
+  my $add_direct_xref_sth = $dbi->prepare($sql);
+
+  $add_direct_xref_sth->execute($general_xref_id, $ensembl_stable_id, $linkage_type);
+  $add_direct_xref_sth->finish();
+
+  if ( $update_info_type ) {
+    $self->_update_xref_info_type( $general_xref_id, 'DIRECT', $dbi );
+  }
+
+  return;
+}
+
+
+##########################################################
+# Create/Add xref and add it as a dependency of the master
+# Note that a corresponding method for direct xrefs is called add_to_direct_xrefs()
+##########################################################
+sub add_dependent_xref{
+  my ($self, $arg_ref) = @_;
+
+  my $master_xref = $arg_ref->{master_xref_id} || croak( 'Need a master_xref_id on which this xref depends on' );
+  my $acc         = $arg_ref->{acc}            || croak( 'Need an accession of this dependent xref' );
+  my $source_id   = $arg_ref->{source_id}      || croak( 'Need a source_id for this dependent xref' );
+  my $species_id  = $arg_ref->{species_id}     || croak( 'Need a species_id for this dependent xref' );
+  my $version     = $arg_ref->{version}        // 0;
+  my $label       = $arg_ref->{label}          // $acc;
+  my $description = $arg_ref->{desc};
+  my $linkage     = $arg_ref->{linkage};
+  my $info_text   = $arg_ref->{info_text}      // q{};
+  my $dbi         = $arg_ref->{dbi};
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sql = (<<'IXR');
+INSERT INTO xref
+  (accession,version,label,description,source_id,species_id, info_type, info_text)
+  VALUES (?,?,?,?,?,?,?,?)
+IXR
+  my $add_xref_sth = $dbi->prepare($sql);
+
+  ####################################################
+  # Does the xref already exist. If so get its xref_id
+  # else create it and get the new xref_id
+  ####################################################
+  my $dependent_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
+  if(!(defined $dependent_id)){
+    $add_xref_sth->execute(
+        $acc, $version, $label,
+        $description, $source_id, $species_id, 'DEPENDENT', $info_text
+    ) or croak("$acc\t$label\t\t$source_id\t$species_id\n");
+  }
+  $add_xref_sth->finish();
+
+  ################################################
+  # Croak if we have failed to create/get the xref
+  ################################################
+  $dependent_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
+  if ( !$dependent_id ) {
+    croak("$acc\t$label\t\t$source_id\t$species_id\n");
+  }
+
+  ################################
+  # Now add the dependency mapping
+  ################################
+  $self->add_dependent_xref_maponly( $dependent_id, $source_id,
+                                     $master_xref, $linkage,
+                                     $dbi );
+
+  return $dependent_id;
+}
+
+
+##################################################################
+# Add a single record to the dependent_xref table.
+# Note that an xref must already have been added to the xref table
+# Note that a corresponding method for direct xrefs is called add_direct_xref()
+##################################################################
+
+sub add_dependent_xref_maponly {
+  my ( $self, $dependent_id, $dependent_source_id, $master_id, $master_source_id, $dbi, $update_info_type ) = @_;
+
+  $dbi //= $self->dbi;
+
+  my $sql = (<<'ADX');
+INSERT INTO dependent_xref 
+  (master_xref_id,dependent_xref_id,linkage_annotation,linkage_source_id)
+  VALUES (?,?,?,?)
+ADX
+  my $add_dependent_xref_sth = $dbi->prepare($sql);
+
+  # If the dependency cannot be found in %xref_dependent_mapped,
+  # i.e. has not been set yet, add it
+  if ( ( ! defined $xref_dependent_mapped{"$master_id|$dependent_id"} )
+       || $xref_dependent_mapped{"$master_id|$dependent_id"} ne $master_source_id ) {
+
+    $add_dependent_xref_sth->execute( $master_id, $dependent_id,
+                                      $master_source_id, $dependent_source_id )
+      || croak("$master_id\t$dependent_id\t$master_source_id\t$dependent_source_id");
+
+    $xref_dependent_mapped{"$master_id|$dependent_id"} = $master_source_id;
+  }
+
+  $add_dependent_xref_sth->finish();
+
+  if ( $update_info_type ) {
+    $self->_update_xref_info_type( $dependent_id, 'DEPENDENT', $dbi );
+  }
+
+  return;
+}
+
+
+##################################################################
+# Add synonyms for a particular accession for one or more sources.
+# This is for priority xrefs where we have more than one source
+# but want to write synonyms for each with the same accession
+##################################################################
+sub add_to_syn_for_mult_sources{
+  my ($self, $acc, $sources, $syn, $species_id, $dbi) = @_;
+
+  $dbi = $self->dbi unless defined $dbi;
+  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
+
+  foreach my $source_id (@{$sources}){
+    my $xref_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
+    if(defined $xref_id){
+      $add_synonym_sth->execute( $xref_id, $syn )
+        or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
+    }
+  }
+  $add_synonym_sth->finish();
+  return;
+}
+
+
+##########################################################
+# Add synomyn for an xref given by accession and source_id
+##########################################################
+sub add_to_syn{
+  my ($self, $acc, $source_id, $syn, $species_id, $dbi) = @_;
+
+  $dbi = $self->dbi unless defined $dbi;
+  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
+  my $xref_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
+  if(defined $xref_id){
+    $add_synonym_sth->execute( $xref_id, $syn )
+      or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
+  }
+  else {
+      carp (  "Could not find acc $acc in "
+            . "xref table source = $source_id of species $species_id\n" );
+  }
+  $add_synonym_sth->finish();
+  return;
+}
+
+
+##########################################
+# Add synomyn for an xref given by xref_id
+##########################################
+sub add_synonym{
+  my ($self, $xref_id, $syn, $dbi) = @_;
+
+  $dbi = $self->dbi unless defined $dbi;
+  my $add_synonym_sth = $dbi->prepare_cached('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
+  
+  $add_synonym_sth->execute( $xref_id, $syn ) 
+    or croak( $dbi->errstr()."\n $xref_id\n $syn\n\n" );
+
+  $add_synonym_sth->finish();
+  return;
+}
+
+########################################################
+# Create a hash that uses the label as a key
+# and the acc as the value. Also add synonyms for these
+# as keys.
+#######################################################
+sub get_label_to_acc{
+  my ($self, $name, $species_id, $prio_desc, $dbi) = @_;
+  my %hash1=();
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sql =(<<"GLA");
+SELECT  xref.accession, xref.label
+  FROM xref, source
+    WHERE source.name LIKE '$name%' AND
+          xref.source_id = source.source_id
+GLA
+  if(defined $prio_desc){
+    $sql .= " and source.priority_description like '$prio_desc'";
+  }
+  if(defined $species_id){
+    $sql .= " and xref.species_id  = $species_id";
+  }
+  my $sub_sth = $dbi->prepare($sql);
+
+  $sub_sth->execute();
+  while(my @row = $sub_sth->fetchrow_array()) {
+    $hash1{$row[1]} = $row[0];
+  }
+
+
+  ####################
+  # Remember synonyms
+  ####################
+
+ $sql =(<<"GLS");
+SELECT  xref.accession, synonym.synonym 
+  FROM xref, source, synonym 
+    WHERE synonym.xref_id = xref.xref_id AND
+          source.name like '$name%' AND
+           xref.source_id = source.source_id
+GLS
+
+  if(defined $prio_desc){
+    $sql .= " AND source.priority_description LIKE '$prio_desc'";
+  }
+  if(defined $species_id){
+    $sql .= " AND xref.species_id  = $species_id";
+  }
+  $sub_sth = $dbi->prepare($sql);
+
+  $sub_sth->execute();
+  while(my @row = $sub_sth->fetchrow_array()) {
+    $hash1{$row[1]} = $row[0];
+  }
+  $sub_sth->finish();
+
+  return \%hash1;
+}
+
+########################################################
+# Create a hash that uses the accession as a key
+# and the label as the value.
+#######################################################
+sub get_acc_to_label{
+  my ($self, $name, $species_id, $prio_desc, $dbi) = @_;
+  my %hash1=();
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sql =(<<"GLA");
+SELECT  xref.accession, xref.label
+  FROM xref, source
+    WHERE source.name LIKE '$name%' AND
+          xref.source_id = source.source_id
+GLA
+  if(defined $prio_desc){
+    $sql .= " and source.priority_description like '$prio_desc'";
+  }
+  if(defined $species_id){
+    $sql .= " and xref.species_id  = $species_id";
+  }
+  my $sub_sth = $dbi->prepare($sql);
+
+  $sub_sth->execute();
+  while(my @row = $sub_sth->fetchrow_array()) {
+    $hash1{$row[0]} = $row[1];
+  }
+  $sub_sth->finish();
+
+  return \%hash1;
+}
+
+
+########################################################
+# Create a hash that uses the label as a key
+# and the desc as the value. Also add synonyms for these
+# as keys.
+#######################################################
+sub get_label_to_desc{
+  my ($self, $name, $species_id, $prio_desc, $dbi) = @_;
+  my %hash1=();
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sql =(<<"GDH");
+  SELECT xref.description, xref.label 
+    FROM xref, source 
+      WHERE source.name LIKE '$name%' AND 
+            xref.source_id = source.source_id
+GDH
+  if(defined $prio_desc){
+    $sql .= " and source.priority_description like '$prio_desc'";
+  }
+  if(defined $species_id){
+    $sql .= " and xref.species_id  = $species_id";
+  }
+  my $sub_sth = $dbi->prepare($sql);
+
+  $sub_sth->execute();
+  while(my @row = $sub_sth->fetchrow_array()) {
+    $hash1{$row[1]} = $row[0];
+  }
+
+  ###########################
+  # Also include the synonyms
+  ###########################
+
+  my $syn_sql =(<<"GDS");
+  SELECT xref.description, synonym.synonym
+    FROM xref, source, synonym
+      WHERE synonym.xref_id = xref.xref_id AND
+            source.name like '$name%' AND
+             xref.source_id = source.source_id
+GDS
+
+  if(defined $prio_desc){
+    $syn_sql .= " AND source.priority_description LIKE '$prio_desc'";
+  }
+  if(defined $species_id){
+    $syn_sql .= " AND xref.species_id  = $species_id";
+  }
+  $sub_sth = $dbi->prepare($syn_sql);
+
+  $sub_sth->execute();
+  while(my @row = $sub_sth->fetchrow_array()) {
+    $hash1{$row[1]} = $row[0];
+  }
+  $sub_sth->finish();
+
+  return \%hash1;
+}
+
+
+########################################
+# Set release for a particular source_id.
+########################################
+sub set_release{
+    my ($self, $source_id, $s_release, $dbi ) = @_;
+
+   $dbi = $self->dbi unless defined $dbi;
+
+    my $sth =
+      $dbi->prepare('UPDATE source SET source_release=? WHERE source_id=?');
+
+    if($verbose) { print "Setting release to '$s_release' for source ID '$source_id'\n"; }
+
+    $sth->execute( $s_release, $source_id );
+    $sth->finish();
+    return;
+}
+
+
+#############################################################################
+# create a hash of all the dependent mapping that exist for a given source_id
+# Of the format {master_xref_id|dependent_xref_id}
+#############################################################################
+sub get_dependent_mappings {
+  my $self = shift;
+  my $source_id = shift;
+  my $dbi = shift;
+
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sql =(<<"GDM");
+  SELECT  d.master_xref_id, d.dependent_xref_id, d.linkage_annotation
+    FROM dependent_xref d, xref x
+      WHERE x.xref_id = d.dependent_xref_id AND
+            x.source_id = $source_id
+GDM
+  my $sth = $dbi->prepare($sql);
+  $sth->execute();
+  my $master_xref;
+  my $dependent_xref;
+  my $linkage;
+  $sth->bind_columns(\$master_xref, \$dependent_xref, \$linkage);
+  while($sth->fetch){
+    $xref_dependent_mapped{"$master_xref|$dependent_xref"} = $linkage;
+  }
+  $sth->finish;
+  return;
+}
+
+
+##########################################################
+# Create a has that uses the accession and labels for keys
+# and an array of the synonyms as the vaules
+##########################################################
+sub get_ext_synonyms{
+  my $self = shift;
+  my $source_name = shift;
+  my $dbi = shift;
+  $dbi = $self->dbi unless defined $dbi;
+  my %ext_syns;
+  my %seen;          # can be in more than once fro each type of external source.
+  my $separator = qw{:};
+
+  my $sql =(<<"GES");
+  SELECT  x.accession, x.label, sy.synonym
+    FROM xref x, source so, synonym sy
+      WHERE x.xref_id = sy.xref_id AND
+            so.source_id = x.source_id AND
+            so.name like '$source_name'
+GES
+  my $sth = $dbi->prepare($sql);
+
+  $sth->execute;
+  my ($acc, $label, $syn);
+  $sth->bind_columns(\$acc, \$label, \$syn);
+
+  my $count = 0;
+  while($sth->fetch){
+    if(!(defined $seen{$acc.$separator.$syn})){
+      push @{$ext_syns{$acc}}, $syn;
+      push @{$ext_syns{$label}}, $syn;
+      $count++;
+    }
+    $seen{$acc.$separator.$syn} = 1;
+  }
+  $sth->finish;
+
+  return \%ext_syns;
+
+}
+
+
+######################################################################
+# Store data needed to beable to revert to same stage as after parsing
+######################################################################
+sub parsing_finished_store_data {
+  my $self = shift;
+  my $dbi = shift;
+  $dbi = $self->dbi unless defined $dbi;
+
+  # Store max id for
+
+  # gene/transcript/translation_direct_xref     general_xref_id  #Does this change??
+
+  # xref                                        xref_id
+  # dependent_xref                              object_xref_id is all null
+  # object_xref                                 object_xref_id
+  # identity_xref                               object_xref_id
+
+  my %table_and_key =
+    ( 'xref' => 'xref_id', 'object_xref' => 'object_xref_id' );
+
+  foreach my $table ( keys %table_and_key ) {
+    my $sth = $dbi->prepare(
+             'select MAX(' . $table_and_key{$table} . ") from $table" );
+    $sth->execute;
+    my $max_val;
+    $sth->bind_columns( \$max_val );
+    $sth->fetch;
+    $sth->finish;
+    $self->add_meta_pair( 'PARSED_' . $table_and_key{$table},
+                          $max_val || 1, $dbi );
+  }
+  return;
+} ## end sub parsing_finished_store_data
+
+
+sub get_meta_value {
+  my ($self, $key, $dbi) = @_;
+  $dbi = $self->dbi unless defined $dbi;
+
+  my $sth = $dbi->prepare('select meta_value from meta where meta_key like "'.$key.'" order by meta_id');
+  $sth->execute();
+  my $value;
+  $sth->bind_columns(\$value);
+  while($sth->fetch){   # get the last one
+  }
+  $sth->finish;
+
+  return $value;
+}
+
+
+######################################
+# Update info_type of an existing xref
+######################################
+sub _update_xref_info_type {
+  my ($self, $xref_id, $info_type, $dbi) = @_;
+
+  $dbi //= $self->dbi;
+
+  my $sth =  $dbi->prepare('UPDATE xref SET info_type=? where xref_id=?');
+  if ( ! $sth->execute( $info_type, $xref_id ) ) {
+    croak $dbi->errstr() . "\n $xref_id\n $info_type\n\n";
+  }
+
+  $sth->finish();
+  return;
+}
+
+
+1;
+

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/BaseParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/BaseParser.pm
@@ -33,45 +33,24 @@ my $base_dir = File::Spec->curdir();
 my %xref_dependent_mapped;
 
 
-my $verbose;
-
-
 ###################################################
 # Create new object.
-#   set global $verbose
-#   Store the dbi form the database for easy access
 ###################################################
 sub new
 {
-  my ($proto, $database, $is_verbose) = @_;
+  my ($proto, $database) = @_;
   my $dbh;
   if(!defined $database){
     croak 'No database specified';
   } elsif ( $database->isa('XrefParser::Database') ) {
     $dbh = $database->dbi;
-  } elsif ( $database->isa('DBI::db') ) {
-    $dbh = $database;
   } else {
     croak sprintf 'I do not recognise your %s class. It must be XrefParser::Database or a DBI $dbh instance'."\n",ref $database;
   }
-  $verbose = $is_verbose;
 
   my $class = ref $proto || $proto;
   my $self =  bless {}, $class;
-  $self->dbi($dbh);
   return $self;
-}
-
-
-##################################
-# Getter/Setter for the dbi object
-##################################
-sub dbi {
-  my ($self, $arg) = @_;
-
-  (defined $arg) &&
-    ($self->{_dbi} = $arg );
-  return $self->{_dbi};
 }
 
 
@@ -129,10 +108,6 @@ sub get_filehandle
 
     if ( !defined $io ) { return }
 
-    if ($verbose) {
-      print "Reading from '$file_name'...\n" || croak 'Could not print out message';
-    }
-
     return $io;
 }
 
@@ -147,7 +122,6 @@ sub get_filehandle
 #############################################
 sub get_source_id_for_source_name {
   my ($self, $source_name,$priority_desc, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
 
   my $low_name = lc $source_name;
   my $sql = "SELECT source_id FROM source WHERE LOWER(name)='$low_name'";
@@ -173,259 +147,6 @@ sub get_source_id_for_source_name {
   return $source_id;
 }
 
-
-
-############################################################
-# Get a set of source IDs matching a source name pattern
-#
-# Adds % to each end of the source name and doe a like query
-# to find all the matching source names source_ids.
-#
-# Returns an empty list if none found.
-############################################################
-sub get_source_ids_for_source_name_pattern {
-
-  my ($self, $source_name, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $big_name = uc $source_name;
-  my $sql = "SELECT source_id FROM source WHERE upper(name) LIKE '%${big_name}%'";
-
-  my $sth = $dbi->prepare($sql);
-  my @sources;
-  $sth->execute();
-  while(my @row = $sth->fetchrow_array()){
-    push @sources,$row[0];
-  }
-  $sth->finish;
-
-  return @sources;
-
-}
-
-
-###############################
-# From a source_id get the name
-###############################
-sub get_source_name_for_source_id {
-  my ($self, $source_id, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-  my $source_name;
-
-  my $sql = "SELECT name FROM source WHERE source_id= '$source_id'";
-  my $sth = $dbi->prepare($sql);
-  $sth->execute();
-  my @row = $sth->fetchrow_array();
-  if (@row) {
-    $source_name = $row[0];
-  } else {
-    carp "There is no entity with source-id  $source_id  in the source-table of the \n";
-    carp "xref-database. The source-id and the name of the source-id is hard-coded in populate_metadata.sql\n" ;
-    carp "and in the parser\n";
-    carp "Couldn't get source name for source ID $source_id\n";
-    $source_name = '-1';
-  }
-  $sth->finish;
-  return $source_name;
-}
-
-
-
-####################################################
-# Get a hash to go from accession of a dependent xref
-# to master_xref_id for all of source names given
-#####################################################
-sub get_valid_xrefs_for_dependencies{
-  my ($self, $dependent_name, $dbi, @reverse_ordered_source_list) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my %dependent_2_xref;
-
-  my $sql = 'select source_id from source where LOWER(name) =?';
-  my $sth = $dbi->prepare($sql);
-  my @dependent_sources;
-  $sth->execute(lc $dependent_name);
-  while(my @row = $sth->fetchrow_array()){
-   push @dependent_sources,$row[0];
-  }
-
-  my @sources;
-  foreach my $name (@reverse_ordered_source_list){
-    $sth->execute(lc $name);
-    while(my @row = $sth->fetchrow_array()){
-      push @sources,$row[0];
-    }
-  }
-  $sth->finish;
-
-  my $dep_sql = (<<'DSS');
-  SELECT d.master_xref_id, x2.accession
-    FROM dependent_xref d, xref x1, xref x2
-      WHERE x1.xref_id = d.master_xref_id AND
-            x1.source_id = ? AND
-            x2.xref_id = d.dependent_xref_id AND
-            x2.source_id = ?
-DSS
-
-  $sth = $dbi->prepare($dep_sql);
-  foreach my $d (@dependent_sources){
-    foreach my $s (@sources){
-       $sth->execute($s,$d);
-       while(my @row = $sth->fetchrow_array()){
-	 $dependent_2_xref{$row[1]} = $row[0];
-       }
-     }
-  }
-  $sth->finish;
-  return \%dependent_2_xref;
-}
-
-
-
-####################################################
-# Get a hash to go from accession of a direct xref
-# to master_xref_id for all of source names given
-#####################################################
-sub get_valid_xrefs_for_direct_xrefs{
-  my ($self, $direct_name, $separator, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my %direct_2_xref;
-
-  my $sql = 'select source_id from source where name like ?';
-  my $sth = $dbi->prepare($sql);
-  my @direct_sources;
-  $sth->execute("${direct_name}%");
-  while(my @row = $sth->fetchrow_array()){
-    push @direct_sources,$row[0];
-  }
-  $sth->finish;
-
-  my $gen_sql =(<<"GDS");
-SELECT d.general_xref_id, d.ensembl_stable_id, 'TYPE', d.linkage_xref, x1.accession
-  FROM TABLE_direct_xref d, xref x1
-    WHERE x1.xref_id = d.general_xref_id AND
-          x1.source_id=?
-GDS
-
-  my @sth;
-  my $i=0;
-  foreach my $type (qw(Gene Transcript Translation)){
-    my $t_sql = $gen_sql;
-    my $table = lc $type;
-    $t_sql =~ s/TABLE/$table/xsm;
-    $t_sql =~ s/TYPE/$type/xsm;
-
-    $sth[$i++] = $dbi->prepare($t_sql);
-  }
-
-  foreach my $d (@direct_sources){
-    for my $ii (0..2) {
-      $sth[$ii]->execute($d);
-      while(my ($gen_xref_id, $stable_id, $type, $link, $acc) = $sth[$ii]->fetchrow_array()){
-	$direct_2_xref{$acc} = $gen_xref_id.$separator.$stable_id.$separator.$type.$separator.$link;
-      }
-      $sth[$ii]->finish();
-    }
-  }
-
-  return \%direct_2_xref;
-}
-
-
-#############################################
-# Get a hash of label to acc for a particular
-# source name and species_id
-#############################################
-sub label_to_acc{
-
-  my ($self,$source_name,$species_id, $dbi) =@_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  # First cache synonyms so we can quickly add them later
-  my %synonyms;
-  my $syn_sth = $dbi->prepare('SELECT xref_id, synonym FROM synonym');
-  $syn_sth->execute();
-
-  my ($xref_id, $synonym);
-  $syn_sth->bind_columns(\$xref_id, \$synonym);
-  while ($syn_sth->fetch()) {
-
-    push @{$synonyms{$xref_id}}, $synonym;
-
-  }
-  $syn_sth->finish;
-
-  my %valid_codes;
-  my @sources;
-
-  my $big_name = uc $source_name;
-  my $sql = "select source_id from source where upper(name) like '%${big_name}%'";
-  my $sth = $dbi->prepare($sql);
-  $sth->execute();
-  while(my @row = $sth->fetchrow_array()){
-    push @sources,$row[0];
-  }
-  $sth->finish;
-
-  foreach my $source (@sources){
-    $sql = "select label, xref_id from xref where species_id = $species_id and source_id = $source";
-    $sth = $dbi->prepare($sql);
-    $sth->execute();
-    while(my @row = $sth->fetchrow_array()){
-      $valid_codes{$row[0]} =$row[1];
-      # add any synonyms for this xref as well
-      foreach my $syn (@{$synonyms{$row[1]}}) {
-	$valid_codes{$syn} = $row[1];
-      }
-    }
-  }
-  $sth->finish;
-  return \%valid_codes;
-}
-
-
-####################################################
-# get_valid_codes
-#
-# hash of accessions to array of xref dbIDs.
-# This is an array becouse more than one entry can
-# exist. i.e. for uniprot and refseq we have direct
-# and sequence match sets and we need to give both.
-#
-# This list is a cache of acceptable IDs in order to
-# reduce querying when attaching external accessions
-# to xrefs.
-####################################################
-sub get_valid_codes{
-
-  my ($self,$source_name,$species_id, $dbi) =@_;
-
-  my %valid_codes;
-  my @sources;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $big_name = uc $source_name;
-  my $sql = "select source_id from source where upper(name) like '%$big_name%'";
-  my $sth = $dbi->prepare($sql);
-  $sth->execute();
-  while(my @row = $sth->fetchrow_array()){
-    push @sources,$row[0];
-  }
-  $sth->finish;
-
-  foreach my $source (@sources){
-    $sql = "select accession, xref_id from xref where species_id = $species_id and source_id = $source";
-    $sth = $dbi->prepare($sql);
-    $sth->execute();
-    while(my @row = $sth->fetchrow_array()){
-      push @{$valid_codes{$row[0]}}, $row[1];
-    }
-  }
-  $sth->finish();
-  return \%valid_codes;
-}
-
 ##############################
 # Upload xrefs to the database
 ##############################
@@ -433,25 +154,15 @@ sub upload_xref_object_graphs {
   my ($self, $rxrefs, $dbi) = @_;
 
   my $count = scalar @{$rxrefs};
-  if($verbose) {
-    print "count = $count\n" || croak 'Could not print out count';
-  }
-
   if ($count) {
 
     #################
     # upload new ones
     ##################
-    if ($verbose) {
-      print "Uploading xrefs\n"
-	|| croak 'Could not print string';
-    }
-
 
     #################################################################################
     # Start of sql needed to add xrefs, primary_xrefs, synonym, dependent_xrefs etc..
     #################################################################################
-    $dbi = $self->dbi unless defined $dbi;
     my $xref_sth = $dbi->prepare('INSERT INTO xref (accession,version,label,description,source_id,species_id, info_type) VALUES(?,?,?,?,?,?,?)');
     my $pri_insert_sth = $dbi->prepare('INSERT INTO primary_xref VALUES(?,?,?,?)');
     my $pri_update_sth = $dbi->prepare('UPDATE primary_xref SET sequence=? WHERE xref_id=?');
@@ -604,7 +315,8 @@ sub upload_xref_object_graphs {
          $self->add_dependent_xref_maponly( $dep_xref_id,
                                             $dep{LINKAGE_SOURCE_ID},
                                             $xref_id,
-                                            $dep{LINKAGE_ANNOTATION});
+                                            $dep{LINKAGE_ANNOTATION},
+				            $dbi);
 
          #########################################################
          # if there are synonyms, add entries in the synonym table
@@ -643,54 +355,6 @@ sub upload_xref_object_graphs {
   return 1;
 }
 
-######################################################################################
-# Add direct xref to the table XXX_direct_xref. (XXX -> Gene.Transcript or Translation
-# Xref has to exist already, this module just adds ot yo the direct_xref table.
-# $direct_xref is a reference to an array of hash objects.
-######################################################################################
-sub upload_direct_xrefs{
-  my ($self, $direct_xref, $dbi)  = @_;
-  $dbi = $self->dbi unless defined $dbi;
-  for my $dr(@{$direct_xref}) {
-
-    ################################################
-    # Find the xref_id for this accession and source
-    ################################################
-    my $general_xref_id = $self->get_xref($dr->{ACCESSION},$dr->{SOURCE_ID},$dr->{SPECIES_ID}, $dbi);
-
-    #######################################################
-    # If found add the direct xref else write error message
-    #######################################################
-    if ($general_xref_id){
-      $self->add_direct_xref($general_xref_id, $dr->{ENSEMBL_STABLE_ID},$dr->{ENSEMBL_TYPE},$dr->{LINKAGE_XREF}, $dbi);
-    }
-    else{
-      print {*STDERR} 'Problem Could not find accession '.$dr->{ACCESSION}.' for source '.$dr->{SOURCE}.
-	' so not able to add direct xref to '.$dr->{ENSEMBL_STABLE_ID}."\n";
-    }
-  }
-  return;
-}
-
-
-
-
-###############################################
-# Insert into the meta table the key and value.
-###############################################
-sub add_meta_pair {
-
-  my ($self, $key, $value, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sth = $dbi->prepare('insert into meta (meta_key, meta_value, date) values("'.$key.'", "'.$value.'", now())');
-  $sth->execute;
-  $sth->finish;
-  return;
-}
-
-
-
 #################################################
 # Create a hash of all the source names for xrefs
 #################################################
@@ -698,7 +362,6 @@ sub get_xref_sources {
 
   my $self = shift;
   my $dbi = shift;
-  $dbi = $self->dbi unless defined $dbi;
   my %sourcename_to_sourceid;
 
   my $sth = $dbi->prepare('SELECT name,source_id FROM source');
@@ -713,173 +376,39 @@ sub get_xref_sources {
   return %sourcename_to_sourceid;
 }
 
-########################################################################
-# Create and return a hash that that goes from species_id to taxonomy_id
-########################################################################
-sub species_id2taxonomy {
-
-  my $self = shift;
-  my $dbi = shift;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my %species_id2taxonomy;
-
-  my $sth = $dbi->prepare('SELECT species_id, taxonomy_id FROM species');
-  $sth->execute() or croak( $dbi->errstr() );
-  while(my @row = $sth->fetchrow_array()) {
-    my $species_id = $row[0];
-    my $taxonomy_id = $row[1];
-    if(defined $species_id2taxonomy{$species_id} ){
-      push @{$species_id2taxonomy{$species_id}}, $taxonomy_id;
-    }
-    else{
-      $species_id2taxonomy{$species_id} = [$taxonomy_id];
-    }
-  }
-  $sth->finish();
-  return %species_id2taxonomy;
-}
-
-
-
-#########################################################################
-# Create and return a hash that that goes from species_id to species name
-#########################################################################
-sub species_id2name {
-  my $self = shift;
-  my $dbi = shift;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my %species_id2name;
-
-  my $sth = $dbi->prepare('SELECT species_id, name FROM species');
-  $sth->execute() or croak( $dbi->errstr() );
-  while ( my @row = $sth->fetchrow_array() ) {
-    my $species_id = $row[0];
-    my $name       = $row[1];
-    $species_id2name{$species_id} = [ $name ];
-  }
-  $sth->finish();
-
-  ##############################################
-  # Also populate the hash with all the aliases.
-  ##############################################
-  $sth = $dbi->prepare('SELECT species_id, aliases FROM species');
-  $sth->execute() or croak( $dbi->errstr() );
-  while ( my @row = $sth->fetchrow_array() ) {
-    my $species_id = $row[0];
-    foreach my $name ( split /,\s*/xms, $row[1] ) {
-      $species_id2name{$species_id} ||= [];
-      push @{$species_id2name{$species_id}}, $name;
-    }
-  }
-  $sth->finish();
-
-  return %species_id2name;
-} ## end sub species_id2name
-
-
-###########################################################################
-# If there was an error, an xref with the same acc & source already exists.
-# If so, find its ID, otherwise get ID of xref just inserted
-###########################################################################
-sub get_xref_id {
-  my ($self, $arg_ref) = @_;
-  my $sth     = $arg_ref->{sth}        || croak 'Need a statement handle for get_xref_id';
-  my $acc     = $arg_ref->{acc}        || croak 'Need an accession for get_xref_id';
-  my $source  = $arg_ref->{source_id}  || croak 'Need an source_id for get_xref_id';
-  my $species = $arg_ref->{species_id} || confess 'Need an species_id for get_xref_id';
-  my $error   = $arg_ref->{error};
-  my $dbi     = $arg_ref->{dbi};
-
-  my $id = $self->get_xref($acc, $source, $species, $dbi);
-
-  return $id;
-}
-
-##################################################################
-# If primary xref already exists for a partiuclar xref_id return 1
-# else return 0;
-##################################################################
-sub primary_xref_id_exists {
-
-  my ($self, $xref_id, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $exists = 0;
-
-  my $sth = $dbi->prepare('SELECT xref_id FROM primary_xref WHERE xref_id=?');
-  $sth->execute($xref_id) or croak( $dbi->errstr() );
-  my @row = $sth->fetchrow_array();
-  my $result = $row[0];
-  if (defined $result) {$exists = 1; }
-  $sth->finish();
-
-  return $exists;
-
-}
-
-############################################
-# Get the tax id for a particular species id
-############################################
-sub get_taxonomy_from_species_id{
-  my ($self,$species_id, $dbi) = @_;
-  my %hash;
-
-  $dbi = $self->dbi unless defined $dbi;
-  my $sth = $dbi->prepare("SELECT taxonomy_id FROM species WHERE species_id = $species_id");
-  $sth->execute() or croak( $dbi->errstr() );
-  while(my @row = $sth->fetchrow_array()) {
-    $hash{$row[0]} = 1;
-  }
-  $sth->finish;
-  return \%hash;
-}
-
 
 #################################################
 # xref_ids for a given stable id and linkage_xref
 #################################################
 sub get_direct_xref{
- my ($self,$stable_id,$type,$link, $dbi) = @_;
- $dbi = $self->dbi unless defined $dbi;
-
- $type = lc $type;
-
- my $sql = "select general_xref_id from ${type}_direct_xref d where ensembl_stable_id = ? and linkage_xref ";
- my @sql_params = ( $stable_id );
- if ( defined $link ) {
-   $sql .= '= ?';
-   push @sql_params, $link;
- }
- else {
-   $sql .= 'is null';
- }
- my  $direct_sth = $dbi->prepare($sql);
-
- $direct_sth->execute( @sql_params ) || croak( $dbi->errstr() );
- if ( wantarray () ) {
-   # Generic behaviour
-
-   my @results;
-
-   my $all_rows = $direct_sth->fetchall_arrayref();
-   foreach my $row_ref ( @{ $all_rows } ) {
-     push @results, $row_ref->[0];
-   }
-
-   return @results;
- }
- else {
-   # Backwards-compatible behaviour. FIXME: can we get rid of it?
-   # There seem to be no parsers present relying on the old behaviour
-   # any more
-   if ( my @row = $direct_sth->fetchrow_array() ) {
-     return $row[0];
-   }
- }
- $direct_sth->finish();
- return;
+  my ($self,$stable_id,$type,$link, $dbi) = @_;
+ 
+  $type = lc $type;
+ 
+  my $sql = "select general_xref_id from ${type}_direct_xref d where ensembl_stable_id = ? and linkage_xref ";
+  my @sql_params = ( $stable_id );
+  if ( defined $link ) {
+    $sql .= '= ?';
+    push @sql_params, $link;
+  }
+  else {
+    $sql .= 'is null';
+  }
+  my  $direct_sth = $dbi->prepare($sql);
+ 
+  $direct_sth->execute( @sql_params ) || croak( $dbi->errstr() );
+  # Generic behaviour
+ 
+  my @results;
+ 
+  my $all_rows = $direct_sth->fetchall_arrayref();
+  foreach my $row_ref ( @{ $all_rows } ) {
+    push @results, $row_ref->[0];
+  }
+ 
+  return @results;
+  $direct_sth->finish();
+  return;
 }
 
 
@@ -889,7 +418,6 @@ sub get_direct_xref{
 ###################################################################
 sub get_xref{
   my ($self,$acc,$source, $species_id, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
 
   #
   # If the statement handle does nt exist create it.
@@ -905,28 +433,6 @@ sub get_xref{
     return $row[0];
   }
   $get_xref_sth->finish();
-  return;
-}
-
-###################################################################
-# return the object_xref_id for a particular xref_id, ensembl_id and ensembl_object_type
-# if not found return undef;
-###################################################################
-sub get_object_xref {
-  my ($self, $xref_id, $ensembl_id, $object_type, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sql = 'select object_xref_id from object_xref where xref_id = ? and ensembl_object_type = ? and ensembl_id = ?';
-  my $get_object_xref_sth = $dbi->prepare($sql);
-
-  #
-  # Find the object_xref_id using the sql above
-  #
-  $get_object_xref_sth->execute( $xref_id, $ensembl_id, $object_type) or croak( $dbi->errstr() );
-  if(my @row = $get_object_xref_sth->fetchrow_array()) {
-    return $row[0];
-  }
-  $get_object_xref_sth->finish();
   return;
 }
 
@@ -948,8 +454,6 @@ sub add_xref {
   my $info_type   = $arg_ref->{info_type}  // 'MISC';
   my $info_text   = $arg_ref->{info_text}  // q{};
   my $dbi         = $arg_ref->{dbi};
-
-  $dbi = $self->dbi unless defined $dbi;
 
   ##################################################################
   # See if it already exists. It so return the xref_id for this one.
@@ -985,76 +489,6 @@ sub add_xref {
   $add_xref_sth->finish();
   return $add_xref_sth->{'mysql_insertid'};
 } ## end sub add_xref
-
-
-###########################################################
-# Create an object_xref..
-# If it already exists it return the object_xref_id
-# else creates it and returns the new object_xref_id
-###########################################################
-
-sub add_object_xref {
-  my ($self, $arg_ref) = @_;
-
-  my $xref_id     = $arg_ref->{xref_id}     || croak 'add_object_xref needs an xref_id';
-  my $ensembl_id  = $arg_ref->{ensembl_id}  || croak 'add_object_xref needs a ensembl_id';
-  my $object_type = $arg_ref->{object_type} || croak 'add_object_xref needs an object_type';
-  my $dbi         = $arg_ref->{dbi};
-
-  $dbi = $self->dbi unless defined $dbi;
-
-  ##################################################################
-  # See if it already exists. It so return the xref_id for this one.
-  ##################################################################
-
-  my $object_xref_id = $self->get_object_xref($xref_id, $ensembl_id, $object_type, $dbi);
-  if(defined $object_xref_id){
-    return $object_xref_id;
-  }
-
-  my $add_object_xref_sth =
-      $dbi->prepare( 'INSERT INTO object_xref'
-         . '(ensembl_id, ensembl_object_type, xref_id) '
-         . 'VALUES(?,?,?)' );
-
-  ####################################
-  # Add the object_xref and croak if it fails
-  ####################################
-  $add_object_xref_sth->execute($ensembl_id, $object_type, $xref_id
-  ) or croak("$ensembl_id\t$object_type\t\t$xref_id\n");
-
-  $add_object_xref_sth->finish();
-  return $add_object_xref_sth->{'mysql_insertid'};
-}
-
-###########################################################
-# Create an identity_xref
-###########################################################
-
-sub add_identity_xref {
-  my ($self, $arg_ref) = @_;
-
-  my $object_xref_id  = $arg_ref->{object_xref_id}  || croak 'add_identity_xref needs an object_xref_id';
-  my $score           = $arg_ref->{score}           || croak 'add_identity_xref needs a score';
-  my $target_identity = $arg_ref->{target_identity} || croak 'add_identity_xref needs a target_identity';
-  my $query_identity  = $arg_ref->{query_identity}  || croak 'add_identity_xref needs a query_identity';
-  my $dbi             = $arg_ref->{dbi};
-
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $add_identity_xref_sth =
-      $dbi->prepare( 'INSERT INTO identity_xref'
-         . '(object_xref_id, score, query_identity, target_identity) '
-         . 'VALUES(?,?,?,?)' );
-
-  ####################################
-  # Add the object_xref and croak if it fails
-  ####################################
-  $add_identity_xref_sth->execute($object_xref_id, $score, $query_identity, $target_identity
-  ) or croak("$object_xref_id\t$score\t\t$query_identity\t$target_identity\n");
-  $add_identity_xref_sth->finish();
-  return;
-}
 
 
 ###################################################################
@@ -1112,16 +546,12 @@ AXX
 # Note that a corresponding method for dependent xrefs is called add_dependent_xref_maponly()
 ##################################################################
 sub add_direct_xref {
-  my ($self, $general_xref_id, $ensembl_stable_id, $ensembl_type, $linkage_type, $dbi, $update_info_type) = @_;
-
-  $dbi = $self->dbi unless defined $dbi;
+  my ($self, $general_xref_id, $ensembl_stable_id, $ensembl_type, $linkage_type, $dbi) = @_;
 
   # Check if such a mapping exists yet. Make sure get_direct_xref() is
   # invoked in list context, otherwise it will fall back to legacy
   # behaviour of returning a single xref_id even when multiple ones
   # match.
-  # Note: get_direct_xref() does not currently cache its output,
-  # consider changing this should performance become an issue
   my @existing_xref_ids = $self->get_direct_xref($ensembl_stable_id,
                                                  $ensembl_type,
                                                  $linkage_type,
@@ -1137,70 +567,7 @@ sub add_direct_xref {
   $add_direct_xref_sth->execute($general_xref_id, $ensembl_stable_id, $linkage_type);
   $add_direct_xref_sth->finish();
 
-  if ( $update_info_type ) {
-    $self->_update_xref_info_type( $general_xref_id, 'DIRECT', $dbi );
-  }
-
   return;
-}
-
-
-##########################################################
-# Create/Add xref and add it as a dependency of the master
-# Note that a corresponding method for direct xrefs is called add_to_direct_xrefs()
-##########################################################
-sub add_dependent_xref{
-  my ($self, $arg_ref) = @_;
-
-  my $master_xref = $arg_ref->{master_xref_id} || croak( 'Need a master_xref_id on which this xref depends on' );
-  my $acc         = $arg_ref->{acc}            || croak( 'Need an accession of this dependent xref' );
-  my $source_id   = $arg_ref->{source_id}      || croak( 'Need a source_id for this dependent xref' );
-  my $species_id  = $arg_ref->{species_id}     || croak( 'Need a species_id for this dependent xref' );
-  my $version     = $arg_ref->{version}        // 0;
-  my $label       = $arg_ref->{label}          // $acc;
-  my $description = $arg_ref->{desc};
-  my $linkage     = $arg_ref->{linkage};
-  my $info_text   = $arg_ref->{info_text}      // q{};
-  my $dbi         = $arg_ref->{dbi};
-
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sql = (<<'IXR');
-INSERT INTO xref
-  (accession,version,label,description,source_id,species_id, info_type, info_text)
-  VALUES (?,?,?,?,?,?,?,?)
-IXR
-  my $add_xref_sth = $dbi->prepare($sql);
-
-  ####################################################
-  # Does the xref already exist. If so get its xref_id
-  # else create it and get the new xref_id
-  ####################################################
-  my $dependent_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
-  if(!(defined $dependent_id)){
-    $add_xref_sth->execute(
-        $acc, $version, $label,
-        $description, $source_id, $species_id, 'DEPENDENT', $info_text
-    ) or croak("$acc\t$label\t\t$source_id\t$species_id\n");
-  }
-  $add_xref_sth->finish();
-
-  ################################################
-  # Croak if we have failed to create/get the xref
-  ################################################
-  $dependent_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
-  if ( !$dependent_id ) {
-    croak("$acc\t$label\t\t$source_id\t$species_id\n");
-  }
-
-  ################################
-  # Now add the dependency mapping
-  ################################
-  $self->add_dependent_xref_maponly( $dependent_id, $source_id,
-                                     $master_xref, $linkage,
-                                     $dbi );
-
-  return $dependent_id;
 }
 
 
@@ -1211,9 +578,7 @@ IXR
 ##################################################################
 
 sub add_dependent_xref_maponly {
-  my ( $self, $dependent_id, $dependent_source_id, $master_id, $master_source_id, $dbi, $update_info_type ) = @_;
-
-  $dbi //= $self->dbi;
+  my ( $self, $dependent_id, $dependent_source_id, $master_id, $master_source_id, $dbi) = @_;
 
   my $sql = (<<'ADX');
 INSERT INTO dependent_xref 
@@ -1236,226 +601,7 @@ ADX
 
   $add_dependent_xref_sth->finish();
 
-  if ( $update_info_type ) {
-    $self->_update_xref_info_type( $dependent_id, 'DEPENDENT', $dbi );
-  }
-
   return;
-}
-
-
-##################################################################
-# Add synonyms for a particular accession for one or more sources.
-# This is for priority xrefs where we have more than one source
-# but want to write synonyms for each with the same accession
-##################################################################
-sub add_to_syn_for_mult_sources{
-  my ($self, $acc, $sources, $syn, $species_id, $dbi) = @_;
-
-  $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
-
-  foreach my $source_id (@{$sources}){
-    my $xref_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
-    if(defined $xref_id){
-      $add_synonym_sth->execute( $xref_id, $syn )
-        or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
-    }
-  }
-  $add_synonym_sth->finish();
-  return;
-}
-
-
-##########################################################
-# Add synomyn for an xref given by accession and source_id
-##########################################################
-sub add_to_syn{
-  my ($self, $acc, $source_id, $syn, $species_id, $dbi) = @_;
-
-  $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth =  $dbi->prepare('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
-  my $xref_id = $self->get_xref($acc, $source_id, $species_id, $dbi);
-  if(defined $xref_id){
-    $add_synonym_sth->execute( $xref_id, $syn )
-      or croak( $dbi->errstr() . "\n $xref_id\n $syn\n" );
-  }
-  else {
-      carp (  "Could not find acc $acc in "
-            . "xref table source = $source_id of species $species_id\n" );
-  }
-  $add_synonym_sth->finish();
-  return;
-}
-
-
-##########################################
-# Add synomyn for an xref given by xref_id
-##########################################
-sub add_synonym{
-  my ($self, $xref_id, $syn, $dbi) = @_;
-
-  $dbi = $self->dbi unless defined $dbi;
-  my $add_synonym_sth = $dbi->prepare_cached('INSERT IGNORE INTO synonym ( xref_id, synonym ) VALUES(?,?)');
-  
-  $add_synonym_sth->execute( $xref_id, $syn ) 
-    or croak( $dbi->errstr()."\n $xref_id\n $syn\n\n" );
-
-  $add_synonym_sth->finish();
-  return;
-}
-
-########################################################
-# Create a hash that uses the label as a key
-# and the acc as the value. Also add synonyms for these
-# as keys.
-#######################################################
-sub get_label_to_acc{
-  my ($self, $name, $species_id, $prio_desc, $dbi) = @_;
-  my %hash1=();
-
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sql =(<<"GLA");
-SELECT  xref.accession, xref.label
-  FROM xref, source
-    WHERE source.name LIKE '$name%' AND
-          xref.source_id = source.source_id
-GLA
-  if(defined $prio_desc){
-    $sql .= " and source.priority_description like '$prio_desc'";
-  }
-  if(defined $species_id){
-    $sql .= " and xref.species_id  = $species_id";
-  }
-  my $sub_sth = $dbi->prepare($sql);
-
-  $sub_sth->execute();
-  while(my @row = $sub_sth->fetchrow_array()) {
-    $hash1{$row[1]} = $row[0];
-  }
-
-
-  ####################
-  # Remember synonyms
-  ####################
-
- $sql =(<<"GLS");
-SELECT  xref.accession, synonym.synonym 
-  FROM xref, source, synonym 
-    WHERE synonym.xref_id = xref.xref_id AND
-          source.name like '$name%' AND
-           xref.source_id = source.source_id
-GLS
-
-  if(defined $prio_desc){
-    $sql .= " AND source.priority_description LIKE '$prio_desc'";
-  }
-  if(defined $species_id){
-    $sql .= " AND xref.species_id  = $species_id";
-  }
-  $sub_sth = $dbi->prepare($sql);
-
-  $sub_sth->execute();
-  while(my @row = $sub_sth->fetchrow_array()) {
-    $hash1{$row[1]} = $row[0];
-  }
-  $sub_sth->finish();
-
-  return \%hash1;
-}
-
-########################################################
-# Create a hash that uses the accession as a key
-# and the label as the value.
-#######################################################
-sub get_acc_to_label{
-  my ($self, $name, $species_id, $prio_desc, $dbi) = @_;
-  my %hash1=();
-
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sql =(<<"GLA");
-SELECT  xref.accession, xref.label
-  FROM xref, source
-    WHERE source.name LIKE '$name%' AND
-          xref.source_id = source.source_id
-GLA
-  if(defined $prio_desc){
-    $sql .= " and source.priority_description like '$prio_desc'";
-  }
-  if(defined $species_id){
-    $sql .= " and xref.species_id  = $species_id";
-  }
-  my $sub_sth = $dbi->prepare($sql);
-
-  $sub_sth->execute();
-  while(my @row = $sub_sth->fetchrow_array()) {
-    $hash1{$row[0]} = $row[1];
-  }
-  $sub_sth->finish();
-
-  return \%hash1;
-}
-
-
-########################################################
-# Create a hash that uses the label as a key
-# and the desc as the value. Also add synonyms for these
-# as keys.
-#######################################################
-sub get_label_to_desc{
-  my ($self, $name, $species_id, $prio_desc, $dbi) = @_;
-  my %hash1=();
-
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sql =(<<"GDH");
-  SELECT xref.description, xref.label 
-    FROM xref, source 
-      WHERE source.name LIKE '$name%' AND 
-            xref.source_id = source.source_id
-GDH
-  if(defined $prio_desc){
-    $sql .= " and source.priority_description like '$prio_desc'";
-  }
-  if(defined $species_id){
-    $sql .= " and xref.species_id  = $species_id";
-  }
-  my $sub_sth = $dbi->prepare($sql);
-
-  $sub_sth->execute();
-  while(my @row = $sub_sth->fetchrow_array()) {
-    $hash1{$row[1]} = $row[0];
-  }
-
-  ###########################
-  # Also include the synonyms
-  ###########################
-
-  my $syn_sql =(<<"GDS");
-  SELECT xref.description, synonym.synonym
-    FROM xref, source, synonym
-      WHERE synonym.xref_id = xref.xref_id AND
-            source.name like '$name%' AND
-             xref.source_id = source.source_id
-GDS
-
-  if(defined $prio_desc){
-    $syn_sql .= " AND source.priority_description LIKE '$prio_desc'";
-  }
-  if(defined $species_id){
-    $syn_sql .= " AND xref.species_id  = $species_id";
-  }
-  $sub_sth = $dbi->prepare($syn_sql);
-
-  $sub_sth->execute();
-  while(my @row = $sub_sth->fetchrow_array()) {
-    $hash1{$row[1]} = $row[0];
-  }
-  $sub_sth->finish();
-
-  return \%hash1;
 }
 
 
@@ -1465,158 +611,12 @@ GDS
 sub set_release{
     my ($self, $source_id, $s_release, $dbi ) = @_;
 
-   $dbi = $self->dbi unless defined $dbi;
-
     my $sth =
       $dbi->prepare('UPDATE source SET source_release=? WHERE source_id=?');
-
-    if($verbose) { print "Setting release to '$s_release' for source ID '$source_id'\n"; }
 
     $sth->execute( $s_release, $source_id );
     $sth->finish();
     return;
-}
-
-
-#############################################################################
-# create a hash of all the dependent mapping that exist for a given source_id
-# Of the format {master_xref_id|dependent_xref_id}
-#############################################################################
-sub get_dependent_mappings {
-  my $self = shift;
-  my $source_id = shift;
-  my $dbi = shift;
-
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sql =(<<"GDM");
-  SELECT  d.master_xref_id, d.dependent_xref_id, d.linkage_annotation
-    FROM dependent_xref d, xref x
-      WHERE x.xref_id = d.dependent_xref_id AND
-            x.source_id = $source_id
-GDM
-  my $sth = $dbi->prepare($sql);
-  $sth->execute();
-  my $master_xref;
-  my $dependent_xref;
-  my $linkage;
-  $sth->bind_columns(\$master_xref, \$dependent_xref, \$linkage);
-  while($sth->fetch){
-    $xref_dependent_mapped{"$master_xref|$dependent_xref"} = $linkage;
-  }
-  $sth->finish;
-  return;
-}
-
-
-##########################################################
-# Create a has that uses the accession and labels for keys
-# and an array of the synonyms as the vaules
-##########################################################
-sub get_ext_synonyms{
-  my $self = shift;
-  my $source_name = shift;
-  my $dbi = shift;
-  $dbi = $self->dbi unless defined $dbi;
-  my %ext_syns;
-  my %seen;          # can be in more than once fro each type of external source.
-  my $separator = qw{:};
-
-  my $sql =(<<"GES");
-  SELECT  x.accession, x.label, sy.synonym
-    FROM xref x, source so, synonym sy
-      WHERE x.xref_id = sy.xref_id AND
-            so.source_id = x.source_id AND
-            so.name like '$source_name'
-GES
-  my $sth = $dbi->prepare($sql);
-
-  $sth->execute;
-  my ($acc, $label, $syn);
-  $sth->bind_columns(\$acc, \$label, \$syn);
-
-  my $count = 0;
-  while($sth->fetch){
-    if(!(defined $seen{$acc.$separator.$syn})){
-      push @{$ext_syns{$acc}}, $syn;
-      push @{$ext_syns{$label}}, $syn;
-      $count++;
-    }
-    $seen{$acc.$separator.$syn} = 1;
-  }
-  $sth->finish;
-
-  return \%ext_syns;
-
-}
-
-
-######################################################################
-# Store data needed to beable to revert to same stage as after parsing
-######################################################################
-sub parsing_finished_store_data {
-  my $self = shift;
-  my $dbi = shift;
-  $dbi = $self->dbi unless defined $dbi;
-
-  # Store max id for
-
-  # gene/transcript/translation_direct_xref     general_xref_id  #Does this change??
-
-  # xref                                        xref_id
-  # dependent_xref                              object_xref_id is all null
-  # object_xref                                 object_xref_id
-  # identity_xref                               object_xref_id
-
-  my %table_and_key =
-    ( 'xref' => 'xref_id', 'object_xref' => 'object_xref_id' );
-
-  foreach my $table ( keys %table_and_key ) {
-    my $sth = $dbi->prepare(
-             'select MAX(' . $table_and_key{$table} . ") from $table" );
-    $sth->execute;
-    my $max_val;
-    $sth->bind_columns( \$max_val );
-    $sth->fetch;
-    $sth->finish;
-    $self->add_meta_pair( 'PARSED_' . $table_and_key{$table},
-                          $max_val || 1, $dbi );
-  }
-  return;
-} ## end sub parsing_finished_store_data
-
-
-sub get_meta_value {
-  my ($self, $key, $dbi) = @_;
-  $dbi = $self->dbi unless defined $dbi;
-
-  my $sth = $dbi->prepare('select meta_value from meta where meta_key like "'.$key.'" order by meta_id');
-  $sth->execute();
-  my $value;
-  $sth->bind_columns(\$value);
-  while($sth->fetch){   # get the last one
-  }
-  $sth->finish;
-
-  return $value;
-}
-
-
-######################################
-# Update info_type of an existing xref
-######################################
-sub _update_xref_info_type {
-  my ($self, $xref_id, $info_type, $dbi) = @_;
-
-  $dbi //= $self->dbi;
-
-  my $sth =  $dbi->prepare('UPDATE xref SET info_type=? where xref_id=?');
-  if ( ! $sth->execute( $info_type, $xref_id ) ) {
-    croak $dbi->errstr() . "\n $xref_id\n $info_type\n\n";
-  }
-
-  $sth->finish();
-  return;
 }
 
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/RefSeqGPFFParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/RefSeqGPFFParser.pm
@@ -67,7 +67,7 @@ sub run {
   if ( !defined( $xrefs ) ) {
     return 1;    #error
   }
-  $self->upload_xref_object_graphs( $xrefs, $dbi )
+  $self->upload_xref_object_graphs( $xrefs, $dbi );
 
 #  if ( defined $release_file ) {
 #    # Parse and set release info.

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/RefSeqGPFFParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/RefSeqGPFFParser.pm
@@ -1,0 +1,256 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+# Parse RefSeq GPFF files to create xrefs.
+
+package Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::RefSeqGPFFParser;
+
+use strict;
+use warnings;
+use Carp;
+use File::Basename;
+
+use base qw( Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::BaseParser);
+
+my $peptide_source_id;
+my $mrna_source_id ;
+my $ncrna_source_id ;
+my $pred_peptide_source_id ;
+my $pred_mrna_source_id ;
+my $pred_ncrna_source_id ;
+my $entrez_source_id;
+my $wiki_source_id;
+my %entrez;
+
+sub run {
+
+  my ($self, $ref_arg) = @_;
+  my $source_id    = $ref_arg->{source_id};
+  my $file         = $ref_arg->{file};
+  my $release_file = $ref_arg->{rel_file};
+  my $dbi          = $ref_arg->{dbi};
+
+  $peptide_source_id =
+    $self->get_source_id_for_source_name('RefSeq_peptide', undef, $dbi);
+  $mrna_source_id =
+    $self->get_source_id_for_source_name('RefSeq_mRNA','refseq', $dbi);
+  $ncrna_source_id =
+    $self->get_source_id_for_source_name('RefSeq_ncRNA', undef, $dbi);
+
+  $pred_peptide_source_id =
+    $self->get_source_id_for_source_name('RefSeq_peptide_predicted', undef, $dbi);
+  $pred_mrna_source_id =
+    $self->get_source_id_for_source_name('RefSeq_mRNA_predicted','refseq', $dbi);
+  $pred_ncrna_source_id =
+    $self->get_source_id_for_source_name('RefSeq_ncRNA_predicted', undef, $dbi);
+
+  $entrez_source_id = $self->get_source_id_for_source_name('EntrezGene', undef, $dbi);
+  $wiki_source_id = $self->get_source_id_for_source_name('WikiGene', undef, $dbi);
+
+  my $xrefs = $self->create_xrefs($file, $dbi);
+  if ( !defined( $xrefs ) ) {
+    return 1;    #error
+  }
+  $self->upload_xref_object_graphs( $xrefs, $dbi )
+
+#  if ( defined $release_file ) {
+#    # Parse and set release info.
+#    my $release_io = $self->get_filehandle($release_file);
+#    local $/ = "\n*";
+#    my $release = $release_io->getline();
+#    $release_io->close();
+#
+#    $release =~ s/\s{2,}/ /g;
+#    $release =~ s/.*(NCBI Reference Sequence.*) Distribution.*/$1/s;
+#    # Put a comma after the release number to make it more readable.
+#    $release =~ s/Release (\d+)/Release $1,/;
+#
+#    $self->set_release( $source_id,              $release, $dbi );
+#    $self->set_release( $peptide_source_id,      $release, $dbi );
+#    $self->set_release( $mrna_source_id,         $release, $dbi );
+#    $self->set_release( $ncrna_source_id,        $release, $dbi );
+#    $self->set_release( $pred_mrna_source_id,    $release, $dbi );
+#    $self->set_release( $pred_ncrna_source_id,   $release, $dbi );
+#    $self->set_release( $pred_peptide_source_id, $release, $dbi );
+#  }
+
+}
+
+# --------------------------------------------------------------------------------
+# Parse file into array of xref objects
+# There are 2 types of RefSeq files that we are interested in:
+# - protein sequence files *.protein.gpff
+# - mRNA sequence files *.rna.gbff
+# Slightly different formats
+
+sub create_xrefs {
+  my ($self, $file, $dbi) = @_;
+
+  my %dependent_sources =  $self->get_xref_sources($dbi);
+
+  my $add_dependent_xref_sth = $dbi->prepare("INSERT INTO dependent_xref  (master_xref_id,dependent_xref_id, linkage_source_id) VALUES (?,?, $entrez_source_id)");
+
+  my $refseq_io = $self->get_filehandle($file);
+
+  if ( !defined $refseq_io ) {
+    print STDERR "ERROR: Can't open RefSeqGPFF file $file\n";
+    return;
+  }
+
+  my @xrefs;
+
+  local $/ = "\/\/\n";
+
+  my $type = $self->type_from_file($file);
+  return unless $type;
+
+  while ( my $entry = $refseq_io->getline() ) {
+
+    my $xref = $self->xref_from_record(
+      $entry, $type,
+      $pred_mrna_source_id, $pred_ncrna_source_id,
+      $mrna_source_id, $ncrna_source_id,
+      $pred_peptide_source_id, $peptide_source_id,
+      $entrez_source_id, $wiki_source_id, $add_dependent_xref_sth,
+     );
+
+      push @xrefs, $xref if $xref;
+
+  } # while <REFSEQ>
+
+  $refseq_io->close();
+
+  return \@xrefs;
+
+}
+sub type_from_file {
+  my ($self, $file) = @_;
+  return 'peptide' if $file =~ /RefSeq_protein/;
+  return 'dna' if $file =~ /rna/;
+  return 'peptide' if $file =~ /protein/;
+  print STDERR "Could not work out sequence type for $file\n";
+  return;
+}
+sub xref_from_record {
+  my ( $self, $entry, $type,
+      $pred_mrna_source_id, $pred_ncrna_source_id,
+      $mrna_source_id, $ncrna_source_id,
+      $pred_peptide_source_id, $peptide_source_id,
+      $entrez_source_id, $wiki_source_id, $add_dependent_xref_sth,
+  ) = @_;
+  chomp $entry;
+
+  my $xref = {};
+  my ($acc) = $entry =~ /ACCESSION\s+(\S+)/;
+  my ($ver) = $entry =~ /VERSION\s+(\S+)/;
+  my ($species_id) = $entry =~ /db_xref=.taxon:(\d+)/;
+
+  # get the right source ID based on $type and whether this is predicted (X*) or not
+  my $source_id;
+  if ($type =~ /dna/) {
+    if ($acc =~ /^XM_/ ){
+      $source_id = $pred_mrna_source_id;
+    } elsif( $acc =~ /^XR/) {
+      $source_id = $pred_ncrna_source_id;
+    } elsif( $acc =~ /^NM/) {
+      $source_id = $mrna_source_id;
+    } elsif( $acc =~ /^NR/) {
+      $source_id = $ncrna_source_id;
+    }
+  } elsif ($type =~ /peptide/) {
+    if ($acc =~ /^XP_/) {
+      $source_id = $pred_peptide_source_id;
+    } else {
+      $source_id = $peptide_source_id;
+    }
+  }
+
+  ( my $acc_no_ver, $ver ) = split( /\./, $ver );
+
+  $xref->{ACCESSION} = $acc;
+  if($acc eq $acc_no_ver){
+    $xref->{VERSION} = $ver;
+  }
+
+  # Description - may be multi-line
+  my ($description) = $entry =~ /DEFINITION\s+([^[]+)/s;
+  print $entry if (length($description) == 0);
+  $description =~ s/\nACCESSION.*//s;
+  $description =~ s/\n//g;
+  $description =~ s/\s+/ /g;
+  $description = substr($description, 0, 255) if (length($description) > 255);
+
+  # Extract sequence
+  my ($seq) = $entry =~ /^\s*ORIGIN\s+(.+)/ms; # /s allows . to match newline
+  my @seq_lines = split /\n/, $seq;
+  my $parsed_seq = "";
+  foreach my $x (@seq_lines) {
+    my ($seq_only) = $x =~ /^\s*\d+\s+(.*)$/;
+    next if (!defined $seq_only);
+    $parsed_seq .= $seq_only;
+  }
+  $parsed_seq =~ s#//##g;    # remove trailing end-of-record character
+  $parsed_seq =~ s#\s##g;    # remove whitespace
+
+  # Extract related pair to current RefSeq accession
+  # For rna file, the pair is the protein_id
+  # For peptide file, the pair is in DBSOURCE REFSEQ accession
+  my ($refseq_pair) = $entry =~ /DBSOURCE\s+REFSEQ: accession (\S+)/;
+  my @protein_id = $entry =~ /\/protein_id=.(\S+_\d+)/g;
+  if (!defined $refseq_pair) {
+    foreach my $pi (@protein_id){
+      $xref->{PAIR} = $pi;
+    }
+  } else {
+    $xref->{PAIR} = $refseq_pair;
+  }
+
+  $xref->{LABEL} = $acc . "\." . $ver;
+  $xref->{DESCRIPTION} = $description;
+  $xref->{SOURCE_ID} = $source_id;
+  $xref->{SEQUENCE} = $parsed_seq;
+  $xref->{SEQUENCE_TYPE} = $type;
+  $xref->{SPECIES_ID} = $species_id;
+  $xref->{INFO_TYPE} = "SEQUENCE_MATCH";
+
+  # Extrat NCBIGene ids
+  my @EntrezGeneIDline = $entry =~ /db_xref=.GeneID:(\d+)/g;
+  foreach my $ll (@EntrezGeneIDline) {
+    my %dep;
+    if (defined $entrez{$ll}) {
+      $dep{SOURCE_ID} = $entrez_source_id;
+      $dep{LINKAGE_SOURCE_ID} = $source_id;
+      $dep{ACCESSION} = $ll;
+      $dep{LABEL} = $entrez{$ll};
+      push @{$xref->{DEPENDENT_XREFS}}, \%dep;
+
+      my %dep2;
+      $dep2{SOURCE_ID} = $wiki_source_id;
+      $dep2{LINKAGE_SOURCE_ID} = $source_id;
+      $dep2{ACCESSION} = $ll;
+      $dep2{LABEL} = $entrez{$ll};
+      push @{$xref->{DEPENDENT_XREFS}}, \%dep2;
+    }
+  }
+  return $xref;
+}
+
+# --------------------------------------------------------------------------------
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtParser.pm
@@ -1,0 +1,393 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+# Parse UniProt (SwissProt & SPTrEMBL) files to create xrefs.
+#
+# Files actually contain both types of xref, distinguished by ID line;
+#
+# ID   CYC_PIG                 Reviewed;         104 AA.  Swissprot
+# ID   Q3ASY8_CHLCH            Unreviewed;     36805 AA.  SPTrEMBL
+
+
+
+package Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::UniProtParser;
+
+use strict;
+use warnings;
+use Carp;
+use POSIX qw(strftime);
+use File::Basename;
+
+use base qw (Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::BaseParser);;
+
+
+
+sub run {
+
+  my ($self, $ref_arg) = @_;
+  my $source_id    = $ref_arg->{source_id};
+  my $file         = $ref_arg->{file};
+  my $release_file = $ref_arg->{rel_file};
+  my $dbi          = $ref_arg->{dbi};
+
+  $self->create_xrefs( $file, $dbi, $release_file);
+
+  return 0; # successfull
+}
+
+
+# --------------------------------------------------------------------------------
+# Parse file into array of xref objects
+
+sub create_xrefs {
+  my ($self, $file, $dbi, $release_file) = @_;
+
+  my $sp_source_id =
+    $self->get_source_id_for_source_name('Uniprot/SWISSPROT','sequence_mapped', $dbi);
+  my $sptr_source_id =
+    $self->get_source_id_for_source_name('Uniprot/SPTREMBL', 'sequence_mapped', $dbi);
+
+  my $sptr_non_display_source_id =
+    $self->get_source_id_for_source_name('Uniprot/SPTREMBL', 'protein_evidence_gt_2', $dbi);
+
+  my $sp_direct_source_id = $self->get_source_id_for_source_name('Uniprot/SWISSPROT', 'direct', $dbi);
+  my $sptr_direct_source_id = $self->get_source_id_for_source_name('Uniprot/SPTREMBL', 'direct', $dbi);
+
+  my $isoform_source_id = $self->get_source_id_for_source_name('Uniprot_isoform');
+
+  if ( defined $release_file ) {
+    my ($sp_release, $sptr_release);
+    # Parse Swiss-Prot and SpTrEMBL release info from
+    # $release_file.
+    my $release_io = $self->get_filehandle($release_file);
+    while ( defined( my $line = $release_io->getline() ) ) {
+      if ( $line =~ m#(UniProtKB/Swiss-Prot Release .*)# ) {
+        $sp_release = $1;
+      } elsif ( $line =~ m#(UniProtKB/TrEMBL Release .*)# ) {
+        $sptr_release = $1;
+      }
+    }
+    $release_io->close();
+
+    # Set releases
+    $self->set_release( $sp_source_id,        $sp_release, $dbi );
+    $self->set_release( $sptr_source_id,      $sptr_release, $dbi );
+    $self->set_release( $sptr_non_display_source_id, $sptr_release, $dbi );
+    $self->set_release( $sp_direct_source_id, $sp_release, $dbi );
+    $self->set_release( $sptr_direct_source_id,$sptr_release, $dbi );
+  }
+
+  my %dependent_sources = $self->get_xref_sources($dbi);
+
+  my $uniprot_io = $self->get_filehandle($file);
+  if ( !defined $uniprot_io ) { 
+    print STDERR "ERROR: Can't open UniProt file $file\n";
+    return;
+  }
+
+  my @xrefs;
+
+  local $/ = "//\n";
+
+  # Counter to process file in batches
+  my $count = 0;
+
+  while ( $_ = $uniprot_io->getline() ) {
+
+    my $xref;
+    my ($species_id) = $_ =~ /OX\s+[a-zA-Z_]+=([0-9 ,]+).*;/;
+
+    # set accession (and synonyms if more than one)
+    # AC line may have primary accession and possibly several ; separated synonyms
+    # May also be more than one AC line
+    my ($acc) = $_ =~ /(\nAC\s+.+)/s; # will match first AC line and everything else
+
+    my @all_lines = split /\n/, $acc;
+
+    # Check for CC (caution) lines containing certain text
+    # If sequence is from Ensembl, do not use
+    my $ensembl_derived_protein = 0;
+    if ($_ =~ /CAUTION: The sequence shown here is derived from an Ensembl/) {
+      $ensembl_derived_protein = 1;
+    }
+
+    # extract ^AC lines only & build list of accessions
+    my @accessions;
+    foreach my $line (@all_lines) {
+      my ($accessions_only) = $line =~ /^AC\s+(.+)/;
+      push(@accessions, (split /;\s*/, $accessions_only)) if ($accessions_only);
+
+    }
+
+    if(lc($accessions[0]) eq "unreviewed"){
+      print "WARNING: entries with accession of $acc not allowed will be skipped\n";
+      next;
+    }
+    $xref->{INFO_TYPE} = "SEQUENCE_MATCH";
+    $xref->{ACCESSION} = $accessions[0];
+    for (my $a=1; $a <= $#accessions; $a++) {
+      push(@{$xref->{"SYNONYMS"} }, $accessions[$a]);
+    }
+
+    my ($label, $sp_type) = $_ =~ /ID\s+(\w+)\s+(\w+)/;
+    my ($protein_evidence_code) = $_ =~ /PE\s+(\d+)/; 
+    # Capture line with entry version
+    # Example: DT   22-APR-2020, entry version 1.
+    my ($version) = $_ =~ /DT\s+\d+-\w+-\d+, entry version (\d+)/;
+
+    # SwissProt/SPTrEMBL are differentiated by having STANDARD/PRELIMINARY here
+    if ($sp_type =~ /^Reviewed/i) {
+      $xref->{SOURCE_ID} = $sp_source_id;
+    } elsif ($sp_type =~ /Unreviewed/i) {
+
+    #Use normal source only if it is PE levels 1 & 2
+      if (defined($protein_evidence_code) && $protein_evidence_code < 3) {
+          $xref->{SOURCE_ID} = $sptr_source_id;
+      } else {
+          $xref->{SOURCE_ID} = $sptr_non_display_source_id;
+      }
+    } else {
+      next; # ignore if it's neither one nor t'other
+    }
+
+    # some straightforward fields
+    # the previous $label flag of type BRCA2_HUMAN is not used in Uniprot any more, use accession instead
+    $xref->{LABEL} = $accessions[0] ."." . $version;
+    $xref->{VERSION} = $version;
+    $xref->{SPECIES_ID} = $species_id;
+    $xref->{SEQUENCE_TYPE} = 'peptide';
+    $xref->{STATUS} = 'experimental';
+    print "Created xref for species $species_id with " . $xref->{ACCESSION} . "\n";
+
+    # May have multi-line descriptions
+    my ($description_and_rest) = $_ =~ /(DE\s+.*)/s;
+    @all_lines = split /\n/, $description_and_rest;
+
+    # extract ^DE lines only & build cumulative description string
+    my $description = "";
+    my $name        = "";
+    my $sub_description = "";
+
+    foreach my $line (@all_lines) {
+
+      next if(!($line =~ /^DE/));
+
+      # get the data
+      if($line =~ /^DE   RecName: Full=(.*);/){
+        $name .= '; ' if $name ne q{}; #separate multiple sub-names with a '; '
+        $name .= $1;
+      }
+      elsif($line =~ /RecName: Full=(.*);/){
+        $description .= ' ' if $description ne q{}; #separate the description bit with just a space
+        $description .= $1;
+      }
+      elsif($line =~ /SubName: Full=(.*);/){
+        $name .= '; ' if $name ne q{}; #separate multiple sub-names with a '; '
+        $name .= $1;
+      }
+
+
+      $description =~ s/^\s*//g;
+      $description =~ s/\s*$//g;
+
+      
+      my $desc = $name.' '.$description;
+      if(!length($desc)){
+	$desc = $sub_description;
+      }
+      
+      $desc =~ s/\s*\{ECO:.*?\}//g;
+      $xref->{DESCRIPTION} = $desc;
+
+      # Parse the EC_NUMBER line, only for S.cerevisiae for now
+      
+      if (($line =~ /EC=/) && ($species_id == 4932)) {
+
+	  $line =~ /^DE\s+EC=([^;]+);/;
+	  # Get the EC Number and make it an xref for S.cer if any
+	  my $EC = $1;
+	  
+	  my %depe;
+	  $depe{LABEL} = $EC;
+	  $depe{ACCESSION} = $EC;
+	  $depe{SOURCE_NAME} = "EC_NUMBER";
+	  $depe{SOURCE_ID} = $dependent_sources{"EC_NUMBER"};
+	  $depe{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
+	  push @{$xref->{DEPENDENT_XREFS}}, \%depe;
+	  print "Added dependent EC xrefs with $EC as accession\n";
+      }
+    }
+
+    # extract sequence
+    my ($seq) = $_ =~ /SQ\s+(.+)/s; # /s allows . to match newline
+      my @seq_lines = split /\n/, $seq;
+    my $parsed_seq = "";
+    foreach my $x (@seq_lines) {
+      $parsed_seq .= $x;
+    }
+    $parsed_seq =~ s/\/\///g;   # remove trailing end-of-record character
+    $parsed_seq =~ s/\s//g;     # remove whitespace
+    $parsed_seq =~ s/^.*;//g;   # remove everything before last ;
+    $xref->{SEQUENCE} = $parsed_seq;
+    #print "Adding " . $xref->{ACCESSION} . " " . $xref->{LABEL} ."\n";
+
+    my ($gns) = $_ =~ /(GN\s+.+)/s;
+    my @gn_lines = ();
+    if ( defined $gns ) { @gn_lines = split /;/, $gns }
+  
+    # Do not allow the addition of UniProt Gene Name dependent Xrefs
+    # if the protein was imported from Ensembl. Otherwise we will
+    # re-import previously set symbols
+    if(! $ensembl_derived_protein) {
+      my %depe;
+      foreach my $gn (@gn_lines){
+# Make sure these are still lines with Name or Synonyms
+        if (($gn !~ /^GN/ || $gn !~ /Name=/) && $gn !~ /Synonyms=/) { last; }
+        my $gene_name = undef;
+
+        if ($gn =~ / Name=([A-Za-z0-9_\-\.\s]+)/s) { #/s for multi-line entries ; is the delimiter
+# Example line 
+# GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
+          my $name = $1;
+          $name =~ s/\s+$//g; # Remove white spaces that are left over at the end if there was an evidence code
+          $depe{LABEL} = $name; # leave name as is, upper/lower case is relevant in gene names
+	  $depe{ACCESSION} = $xref->{ACCESSION};
+          $gene_name = $depe{ACCESSION};
+
+          $depe{SOURCE_NAME} = "Uniprot_gn";
+          $depe{SOURCE_ID} = $dependent_sources{"Uniprot_gn"};
+          $depe{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
+          push @{$xref->{DEPENDENT_XREFS}}, \%depe;
+        }
+        my @syn;
+        if($gn =~ /Synonyms=(.*)/s){ # use of /s as synonyms can be across more than one line
+# Example line
+# GN   Synonyms=cela2a {ECO:0000313|Ensembl:ENSXETP00000014934},
+# GN   MGC79767 {ECO:0000313|EMBL:AAH80976.1}
+          my $syn = $1;
+          $syn =~ s/{.*}//g;  # Remove any potential evidence codes
+          $syn =~ s/\n//g;    # Remove return carriages, as entry can span several lines
+          $syn =~ s/\s+$//g;  # Remove white spaces that are left over at the end if there was an evidence code
+          #$syn =~ s/^\s+//g;  # Remove white spaces that are left over at the beginning if there was an evidence code
+          $syn =~ s/\s+,/,/g;  # Remove white spaces that are left over before the comma if there was an evidence code
+          @syn = split(/, /,$syn);
+          push (@{$depe{"SYNONYMS"}}, @syn);
+        }
+      }
+    }
+
+    # dependent xrefs - only store those that are from sources listed in the source table
+    my ($deps) = $_ =~ /(DR\s+.+)/s; # /s allows . to match newline
+
+    my @dep_lines = ();
+    if ( defined $deps ) { @dep_lines = split /\n/, $deps }
+
+    my %seen=();  # per record basis
+
+    foreach my $dep (@dep_lines) {
+      #Skipp external sources obtained through other files
+      if ($dep =~ /GO/ || $dep =~ /UniGene/ || $dep =~ /RGD/ || $dep =~ /CCDS/ || $dep =~ /IPI/ || $dep =~ /UCSC/ ||
+	      $dep =~ /SGD/ || $dep =~ /HGNC/ || $dep =~ /MGI/ || $dep =~ /VGNC/ || $dep =~ /Orphanet/ || $dep =~ /ArrayExpress/ ||
+	      $dep =~ /GenomeRNAi/ || $dep =~ /EPD/ || $dep =~ /Xenbase/ || $dep =~ /Reactome/ || $dep =~ /MIM/) { next; }
+      if ($dep =~ /^DR\s+(.+)/) {
+        my ($source, $acc, @extra) = split /;\s*/, $1;
+        # If mapped to Ensembl, add as direct xref
+        if ($source eq "Ensembl") {
+          # Example line:
+          # DR   Ensembl; ENST00000380152; ENSP00000369497; ENSG00000139618.
+          # DR   Ensembl; ENST00000372839; ENSP00000361930; ENSG00000166913. [P31946-1]
+          # $source is Ensembl, $acc is ENST00000380152 and @extra is the rest of the line
+          # If the UniProt accession is repeated here, it links to a specific isoform
+          my %direct;
+          my $isoform;
+          $direct{STABLE_ID} = $extra[0];
+          $direct{ENSEMBL_TYPE} = 'Translation';
+          $direct{LINKAGE_TYPE} = 'DIRECT';
+          if ($xref->{SOURCE_ID} == $sp_source_id) {
+            $direct{SOURCE_ID} = $sp_direct_source_id;
+          } else {
+            $direct{SOURCE_ID} = $sptr_direct_source_id;
+          }
+          push @{$xref->{DIRECT_XREFS}}, \%direct;
+
+          my $uniprot_acc = $accessions[0];
+          if ($extra[1] =~ /($accessions[0]-[0-9]+)/) {
+            $isoform = $1;
+            $self->add_to_direct_xrefs({
+              stable_id  => $extra[0],
+              type       => 'translation',
+              acc        => $isoform,
+              label      => $isoform,
+              dbi        => $dbi,
+              source_id  => $isoform_source_id,
+              linkage    => 'DIRECT',
+              species_id => $species_id
+            });
+          }
+        }
+	if (exists $dependent_sources{$source} ) {
+	  # create dependent xref structure & store it
+	  my %dep;
+          $dep{SOURCE_NAME} = $source;
+          $dep{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
+          $dep{SOURCE_ID} = $dependent_sources{$source};
+	  $dep{ACCESSION} = $acc;
+	  if(!defined($seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}})){
+	    push @{$xref->{DEPENDENT_XREFS}}, \%dep; # array of hashrefs
+	    $seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}} =1;
+	    print "Added dependent for $source as " . $dep{ACCESSION} . "\n";
+	  }
+	  if($dep =~ /EMBL/ && !($dep =~ /ChEMBL/)){
+	    my ($protein_id) = $extra[0];
+	    if(($protein_id ne "-") and (!defined($seen{$source.":".$protein_id}))){
+	      my %dep2;
+	      $dep2{SOURCE_NAME} = $source;
+	      $dep2{SOURCE_ID} = $dependent_sources{"protein_id"};
+	      $dep2{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
+	      # store accession unversioned
+	      $dep2{LABEL} = $protein_id;
+	      my ($prot_acc, $prot_version) = $protein_id =~ /([^.]+)\.([^.]+)/;
+	      $dep2{ACCESSION} = $prot_acc;
+	      $seen{$source.":".$protein_id} = 1;
+	      push @{$xref->{DEPENDENT_XREFS}}, \%dep2; # array of hashrefs
+	      print "Added dependent for $source as " . $dep2{ACCESSION} . "\n";
+	    }
+	  }
+	}
+      }
+    }
+
+    push @xrefs, $xref;
+    $count++;
+
+    if ($count > 1000) {
+      $self->upload_xref_object_graphs(\@xrefs, $dbi);
+      $count = 0;
+      undef @xrefs;
+    }
+
+  }
+
+  $self->upload_xref_object_graphs(\@xrefs, $dbi) if scalar(@xrefs) > 0;
+
+  $uniprot_io->close();
+
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtParser.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/Parser/UniProtParser.pm
@@ -69,7 +69,7 @@ sub create_xrefs {
   my $sp_direct_source_id = $self->get_source_id_for_source_name('Uniprot/SWISSPROT', 'direct', $dbi);
   my $sptr_direct_source_id = $self->get_source_id_for_source_name('Uniprot/SPTREMBL', 'direct', $dbi);
 
-  my $isoform_source_id = $self->get_source_id_for_source_name('Uniprot_isoform');
+  my $isoform_source_id = $self->get_source_id_for_source_name('Uniprot_isoform', undef, $dbi);
 
   if ( defined $release_file ) {
     my ($sp_release, $sptr_release);
@@ -209,7 +209,7 @@ sub create_xrefs {
       
       my $desc = $name.' '.$description;
       if(!length($desc)){
-	$desc = $sub_description;
+        $desc = $sub_description;
       }
       
       $desc =~ s/\s*\{ECO:.*?\}//g;
@@ -219,18 +219,17 @@ sub create_xrefs {
       
       if (($line =~ /EC=/) && ($species_id == 4932)) {
 
-	  $line =~ /^DE\s+EC=([^;]+);/;
-	  # Get the EC Number and make it an xref for S.cer if any
-	  my $EC = $1;
-	  
-	  my %depe;
-	  $depe{LABEL} = $EC;
-	  $depe{ACCESSION} = $EC;
-	  $depe{SOURCE_NAME} = "EC_NUMBER";
-	  $depe{SOURCE_ID} = $dependent_sources{"EC_NUMBER"};
-	  $depe{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
-	  push @{$xref->{DEPENDENT_XREFS}}, \%depe;
-	  print "Added dependent EC xrefs with $EC as accession\n";
+          $line =~ /^DE\s+EC=([^;]+);/;
+          # Get the EC Number and make it an xref for S.cer if any
+          my $EC = $1;
+          
+          my %depe;
+          $depe{LABEL} = $EC;
+          $depe{ACCESSION} = $EC;
+          $depe{SOURCE_NAME} = "EC_NUMBER";
+          $depe{SOURCE_ID} = $dependent_sources{"EC_NUMBER"};
+          $depe{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
+          push @{$xref->{DEPENDENT_XREFS}}, \%depe;
       }
     }
 
@@ -245,7 +244,6 @@ sub create_xrefs {
     $parsed_seq =~ s/\s//g;     # remove whitespace
     $parsed_seq =~ s/^.*;//g;   # remove everything before last ;
     $xref->{SEQUENCE} = $parsed_seq;
-    #print "Adding " . $xref->{ACCESSION} . " " . $xref->{LABEL} ."\n";
 
     my ($gns) = $_ =~ /(GN\s+.+)/s;
     my @gn_lines = ();
@@ -257,18 +255,16 @@ sub create_xrefs {
     if(! $ensembl_derived_protein) {
       my %depe;
       foreach my $gn (@gn_lines){
-# Make sure these are still lines with Name or Synonyms
+        # Make sure these are still lines with Name or Synonyms
         if (($gn !~ /^GN/ || $gn !~ /Name=/) && $gn !~ /Synonyms=/) { last; }
-        my $gene_name = undef;
 
         if ($gn =~ / Name=([A-Za-z0-9_\-\.\s]+)/s) { #/s for multi-line entries ; is the delimiter
-# Example line 
-# GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
+          # Example line 
+          # GN   Name=ctrc {ECO:0000313|Xenbase:XB-GENE-5790348};
           my $name = $1;
           $name =~ s/\s+$//g; # Remove white spaces that are left over at the end if there was an evidence code
           $depe{LABEL} = $name; # leave name as is, upper/lower case is relevant in gene names
-	  $depe{ACCESSION} = $xref->{ACCESSION};
-          $gene_name = $depe{ACCESSION};
+          $depe{ACCESSION} = $xref->{ACCESSION};
 
           $depe{SOURCE_NAME} = "Uniprot_gn";
           $depe{SOURCE_ID} = $dependent_sources{"Uniprot_gn"};
@@ -277,9 +273,9 @@ sub create_xrefs {
         }
         my @syn;
         if($gn =~ /Synonyms=(.*)/s){ # use of /s as synonyms can be across more than one line
-# Example line
-# GN   Synonyms=cela2a {ECO:0000313|Ensembl:ENSXETP00000014934},
-# GN   MGC79767 {ECO:0000313|EMBL:AAH80976.1}
+          # Example line
+          # GN   Synonyms=cela2a {ECO:0000313|Ensembl:ENSXETP00000014934},
+          # GN   MGC79767 {ECO:0000313|EMBL:AAH80976.1}
           my $syn = $1;
           $syn =~ s/{.*}//g;  # Remove any potential evidence codes
           $syn =~ s/\n//g;    # Remove return carriages, as entry can span several lines
@@ -303,8 +299,8 @@ sub create_xrefs {
     foreach my $dep (@dep_lines) {
       #Skipp external sources obtained through other files
       if ($dep =~ /GO/ || $dep =~ /UniGene/ || $dep =~ /RGD/ || $dep =~ /CCDS/ || $dep =~ /IPI/ || $dep =~ /UCSC/ ||
-	      $dep =~ /SGD/ || $dep =~ /HGNC/ || $dep =~ /MGI/ || $dep =~ /VGNC/ || $dep =~ /Orphanet/ || $dep =~ /ArrayExpress/ ||
-	      $dep =~ /GenomeRNAi/ || $dep =~ /EPD/ || $dep =~ /Xenbase/ || $dep =~ /Reactome/ || $dep =~ /MIM/) { next; }
+              $dep =~ /SGD/ || $dep =~ /HGNC/ || $dep =~ /MGI/ || $dep =~ /VGNC/ || $dep =~ /Orphanet/ || $dep =~ /ArrayExpress/ ||
+              $dep =~ /GenomeRNAi/ || $dep =~ /EPD/ || $dep =~ /Xenbase/ || $dep =~ /Reactome/ || $dep =~ /MIM/) { next; }
       if ($dep =~ /^DR\s+(.+)/) {
         my ($source, $acc, @extra) = split /;\s*/, $1;
         # If mapped to Ensembl, add as direct xref
@@ -341,35 +337,33 @@ sub create_xrefs {
             });
           }
         }
-	if (exists $dependent_sources{$source} ) {
-	  # create dependent xref structure & store it
-	  my %dep;
+        if (exists $dependent_sources{$source} ) {
+          # create dependent xref structure & store it
+          my %dep;
           $dep{SOURCE_NAME} = $source;
           $dep{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
           $dep{SOURCE_ID} = $dependent_sources{$source};
-	  $dep{ACCESSION} = $acc;
-	  if(!defined($seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}})){
-	    push @{$xref->{DEPENDENT_XREFS}}, \%dep; # array of hashrefs
-	    $seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}} =1;
-	    print "Added dependent for $source as " . $dep{ACCESSION} . "\n";
-	  }
-	  if($dep =~ /EMBL/ && !($dep =~ /ChEMBL/)){
-	    my ($protein_id) = $extra[0];
-	    if(($protein_id ne "-") and (!defined($seen{$source.":".$protein_id}))){
-	      my %dep2;
-	      $dep2{SOURCE_NAME} = $source;
-	      $dep2{SOURCE_ID} = $dependent_sources{"protein_id"};
-	      $dep2{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
-	      # store accession unversioned
-	      $dep2{LABEL} = $protein_id;
-	      my ($prot_acc, $prot_version) = $protein_id =~ /([^.]+)\.([^.]+)/;
-	      $dep2{ACCESSION} = $prot_acc;
-	      $seen{$source.":".$protein_id} = 1;
-	      push @{$xref->{DEPENDENT_XREFS}}, \%dep2; # array of hashrefs
-	      print "Added dependent for $source as " . $dep2{ACCESSION} . "\n";
-	    }
-	  }
-	}
+          $dep{ACCESSION} = $acc;
+          if(!defined($seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}})){
+            push @{$xref->{DEPENDENT_XREFS}}, \%dep; # array of hashrefs
+            $seen{$dep{SOURCE_NAME}.":".$dep{ACCESSION}} =1;
+          }
+          if($dep =~ /EMBL/ && !($dep =~ /ChEMBL/)){
+            my ($protein_id) = $extra[0];
+            if(($protein_id ne "-") and (!defined($seen{$source.":".$protein_id}))){
+              my %dep2;
+              $dep2{SOURCE_NAME} = $source;
+              $dep2{SOURCE_ID} = $dependent_sources{"protein_id"};
+              $dep2{LINKAGE_SOURCE_ID} = $xref->{SOURCE_ID};
+              # store accession unversioned
+              $dep2{LABEL} = $protein_id;
+              my ($prot_acc, $prot_version) = $protein_id =~ /([^.]+)\.([^.]+)/;
+              $dep2{ACCESSION} = $prot_acc;
+              $seen{$source.":".$protein_id} = 1;
+              push @{$xref->{DEPENDENT_XREFS}}, \%dep2; # array of hashrefs
+            }
+          }
+        }
       }
     }
 

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/PreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/PreParse.pm
@@ -1,0 +1,62 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License..
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::Xrefs::PreParse;
+
+use strict;
+use warnings;
+use File::Path qw(make_path);
+
+use parent qw/Bio::EnsEMBL::Production::Pipeline::Xrefs::Base/;
+
+sub run {
+  my ($self) = @_;
+
+  my $parser       = $self->param_required('parser');
+  my $xref_url     = $self->param_required('xref_url');
+  my $name         = $self->param_required('name');
+  my $version_file = $self->param('version_file');
+  my $file         = $self->param_required('file');
+  my $dbname       = $self->param_required('dbname');
+
+  my ($user, $pass, $host, $port) = $self->parse_url($xref_url);
+
+  my $xref_dbc = XrefParser::Database->new({
+            host    => $host,
+            dbname  => $dbname,
+            port    => $port,
+            user    => $user,
+            pass    => $pass });
+  $xref_dbc->disconnect_if_idle();
+
+  my $dbi = $self->get_dbi($host, $port, $user, $pass, $dbname);
+
+  my $source_id = $self->get_source_id($dbi, $parser, 1, $name, 1);
+
+  my $module = "Bio::EnsEMBL::Production::Pipeline::Xrefs::Parser::$parser";
+  eval "require $module";
+  my $xref_run = $module->new($xref_dbc);
+  $xref_run->run(
+    { source_id => $source_id,
+      rel_file => $version_file,
+      dbi      => $dbi,
+      file     => $file }) ;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/PreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/PreParse.pm
@@ -33,9 +33,8 @@ sub run {
   my $name         = $self->param_required('name');
   my $version_file = $self->param('version_file');
   my $file         = $self->param_required('file');
-  my $dbname       = $self->param_required('dbname');
 
-  my ($user, $pass, $host, $port) = $self->parse_url($xref_url);
+  my ($user, $pass, $host, $port, $dbname) = $self->parse_url($xref_url);
 
   my $xref_dbc = XrefParser::Database->new({
             host    => $host,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleDownload.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/ScheduleDownload.pm
@@ -44,12 +44,14 @@ sub run {
     my $file = $source->{'file'};
     my $db = $source->{'db'};
     my $version_file = $source->{'release'};
+    my $preparse = $source->{'preparse'};
     $dataflow_params = {
       parser       => $parser,
       name         => $name,
       priority     => $priority,
       db           => $db,
       version_file => $version_file,
+      preparse     => $preparse,
       db_url       => $db_url,
       file         => $file,
       skip_download=> $skip_download,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
@@ -45,10 +45,10 @@ sub run {
   # Retrieve list of sources to pre-parse from versioning database
   my ($source_user, $source_pass, $source_host, $source_port, $source_db) = $self->parse_url($source_url);
   my $dbi = $self->get_dbi($source_host, $source_port, $source_user, $source_pass, $source_db);
-  my $select_source_sth = $dbi->prepare("SELECT distinct name, parser, uri, clean_uri, revision FROM source s, version v WHERE s.source_id = v.source_id and preparse = 1");
-  my ($name, $parser, $dir, $clean_dir, $version_file);
+  my $select_source_sth = $dbi->prepare("SELECT distinct name, parser, uri, clean_uri, revision, count_seen FROM source s, version v WHERE s.source_id = v.source_id and preparse = 1");
+  my ($name, $parser, $dir, $clean_dir, $version_file, $priority);
   $select_source_sth->execute();
-  $select_source_sth->bind_columns(\$name, \$parser, \$dir, \$clean_dir, \$version_file);
+  $select_source_sth->bind_columns(\$name, \$parser, \$dir, \$clean_dir, \$version_file, \$priority);
 
   my $dataflow_params;
   while ($select_source_sth->fetch()) {
@@ -64,7 +64,7 @@ sub run {
         xref_url     => $source_xref,
         file         => $file,
       };
-      $self->dataflow_output_id($dataflow_params, 2);
+      $self->dataflow_output_id($dataflow_params, $priority);
     }
   }
 }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2021] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::Production::Pipeline::Xrefs::SchedulePreParse;
+
+use strict;
+use warnings;
+
+use parent qw/Bio::EnsEMBL::Production::Pipeline::Xrefs::Base/;
+
+sub run {
+  my ($self) = @_;
+  my $source_url       = $self->param_required('source_url');
+  my $release          = $self->param('release');
+  my $sql_dir          = $self->param('sql_dir');
+
+  my ($user, $pass, $host, $port) = $self->parse_url($source_url);
+
+  # Create central Xref database
+  my $dbname = "xref_source_preparse_" . $release;
+  my $xref_dbc = XrefParser::Database->new({
+            host    => $host,
+            dbname  => $dbname,
+            port    => $port,
+            user    => $user,
+            pass    => $pass });
+  $xref_dbc->create($sql_dir, 1, 1);
+
+  # Retrieve list of sources to pre-parse from versioning database
+  my ($source_user, $source_pass, $source_host, $source_port, $source_db) = $self->parse_url($source_url);
+  my $dbi = $self->get_dbi($source_host, $source_port, $source_user, $source_pass, $source_db);
+  my $select_source_sth = $dbi->prepare("SELECT distinct name, parser, uri, clean_uri, revision FROM source s, version v WHERE s.source_id = v.source_id and preparse = 1");
+  my ($name, $parser, $dir, $clean_dir, $version_file);
+  $select_source_sth->execute();
+  $select_source_sth->bind_columns(\$name, \$parser, \$dir, \$clean_dir, \$version_file);
+
+  my $dataflow_params;
+  while ($select_source_sth->fetch()) {
+    if (defined $clean_dir) { $dir = $clean_dir; }
+    my @files = `ls $dir`;
+    foreach my $file (@files) {
+      $file =~ s/\n//;
+      $file = $dir . "/" . $file;
+      $dataflow_params = {
+        parser       => $parser,
+        name         => $name,
+        version_file => $version_file,
+        xref_url     => $source_url,
+        file         => $file,
+        dbname       => $dbname,
+      };
+      $self->dataflow_output_id($dataflow_params, 2);
+    }
+  }
+}
+
+1;
+

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
@@ -27,19 +27,19 @@ use parent qw/Bio::EnsEMBL::Production::Pipeline::Xrefs::Base/;
 sub run {
   my ($self) = @_;
   my $source_url       = $self->param_required('source_url');
-  my $release          = $self->param('release');
-  my $sql_dir          = $self->param('sql_dir');
+  my $sql_dir          = $self->param_required('sql_dir');
+  my $source_xref      = $self->param_required('source_xref');
 
   my ($user, $pass, $host, $port) = $self->parse_url($source_url);
+  my ($xref_user, $xref_pass, $xref_host, $xref_port, $xref_dbname) = $self->parse_url($source_xref);
 
   # Create central Xref database
-  my $dbname = "xref_source_preparse_" . $release;
   my $xref_dbc = XrefParser::Database->new({
-            host    => $host,
-            dbname  => $dbname,
-            port    => $port,
-            user    => $user,
-            pass    => $pass });
+            host    => $xref_host,
+            dbname  => $xref_dbname,
+            port    => $xref_port,
+            user    => $xref_user,
+            pass    => $xref_pass });
   $xref_dbc->create($sql_dir, 1, 1);
 
   # Retrieve list of sources to pre-parse from versioning database
@@ -61,9 +61,8 @@ sub run {
         parser       => $parser,
         name         => $name,
         version_file => $version_file,
-        xref_url     => $source_url,
+        xref_url     => $source_xref,
         file         => $file,
-        dbname       => $dbname,
       };
       $self->dataflow_output_id($dataflow_params, 2);
     }

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/SchedulePreParse.pm
@@ -67,6 +67,10 @@ sub run {
       $self->dataflow_output_id($dataflow_params, $priority);
     }
   }
+  $dataflow_params = {
+    db_url => $source_url
+  };
+  $self->dataflow_output_id($dataflow_params, -1);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
@@ -53,6 +53,7 @@ CREATE TABLE version (
   uri                      VARCHAR(255),
   index_uri                VARCHAR(255),
   clean_uri                VARCHAR(255),
+  preparse                 BOOLEAN NOT NULL DEFAULT 0,
 
   PRIMARY KEY (version_id),
   KEY version_idx (source_id, revision),

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
@@ -21,16 +21,6 @@
 #  - internal ids are integers named tablename_id
 #  - same name is given in foreign key relations
 
-CREATE TABLE source_group (
-  source_group_id          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-  name                     VARCHAR(128),
-  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
-
-  PRIMARY KEY (source_group_id),
-  unique KEY name_idx (name)
-
-) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
-
 CREATE TABLE checksum_xref (
   checksum_xref_id  INT UNSIGNED NOT NULL AUTO_INCREMENT,
   source_id         INT UNSIGNED NOT NULL,
@@ -45,25 +35,12 @@ CREATE TABLE checksum_xref (
 CREATE TABLE source (
   source_id                INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   name                     VARCHAR(128),
-  source_group_id          INT(10) UNSIGNED,
   active                   BOOLEAN NOT NULL DEFAULT 1,
   created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
-  downloader               VARCHAR(128),
   parser                   VARCHAR(128),
-  current_version          INT(10) UNSIGNED,
 
   PRIMARY KEY (source_id),
-  UNIQUE KEY name_idx (name),
-  FOREIGN KEY (source_group_id) REFERENCES source_group(source_group_id)
-
-) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
-
-CREATE TABLE run (
-  run_id                   INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-  start                    TIMESTAMP NOT NULL DEFAULT NOW(),
-  end                      TIMESTAMP,
-
-  PRIMARY KEY (run_id)
+  UNIQUE KEY name_idx (name)
 
 ) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
 
@@ -73,7 +50,6 @@ CREATE TABLE version (
   revision                 VARCHAR(255),
   created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
   count_seen               INT(10) UNSIGNED NOT NULL,
-  record_count             INT(10),
   uri                      VARCHAR(255),
   index_uri                VARCHAR(255),
   clean_uri                VARCHAR(255),
@@ -84,25 +60,3 @@ CREATE TABLE version (
 
 ) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
 
-CREATE TABLE process (
-  process_id               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-  run_id                   INT(10) UNSIGNED,
-  name                     VARCHAR(128),
-  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
-
-  PRIMARY KEY (process_id),
-  UNIQUE KEY name_idx (name),
-  FOREIGN KEY (run_id) REFERENCES run(run_id)
-
-) COLLATE=latin1_swedish_ci ENGINE=InnoDB;
-
-CREATE TABLE version_run (
-  version_run_id           INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-  version_id               INT(10) UNSIGNED,
-  run_id                   INT(10) UNSIGNED,
-
-  PRIMARY KEY (version_run_id),
-  FOREIGN KEY (version_id) REFERENCES version(version_id),
-  FOREIGN KEY (run_id) REFERENCES run(run_id)
-
-) COLLATE=latin1_swedish_ci ENGINE=InnoDB;

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/sql/table.sql
@@ -36,7 +36,6 @@ CREATE TABLE source (
   source_id                INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   name                     VARCHAR(128),
   active                   BOOLEAN NOT NULL DEFAULT 1,
-  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
   parser                   VARCHAR(128),
 
   PRIMARY KEY (source_id),
@@ -48,7 +47,6 @@ CREATE TABLE version (
   version_id               INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
   source_id                INT(10) UNSIGNED,
   revision                 VARCHAR(255),
-  created_date             TIMESTAMP NOT NULL DEFAULT NOW(),
   count_seen               INT(10) UNSIGNED NOT NULL,
   uri                      VARCHAR(255),
   index_uri                VARCHAR(255),

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_all_sources.json
@@ -1,0 +1,240 @@
+[
+    {
+      "name" : "ArrayExpress",
+      "parser" : "ArrayExpressParser",
+      "file" : "Database",
+      "db" : "core",
+      "priority" : 1
+    },
+    {
+      "name" : "CCDS",
+      "parser" : "CCDSParser",
+      "file" : "Database",
+      "db" : "ccds",
+      "priority" : 1
+    },
+    {
+      "name" : "UniParc",
+      "parser" : "ChecksumParser",
+      "file" : "ftp://ftp.ebi.ac.uk/pub/contrib/uniparc/upidump.lis",
+      "db" : "checksum",
+      "priority" : 1
+    },
+    {
+      "name" : "RNACentral",
+      "parser" : "ChecksumParser",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/md5/md5.tsv.gz",
+      "db" : "checksum",
+      "priority" : 1
+    },
+    {
+      "name" : "DBASS3",
+      "parser" : "DBASSParser",
+      "file" : "https://www.dbass.soton.ac.uk/Dbass3/DownloadCsv",
+      "priority" : 1
+    },
+    {
+      "name" : "DBASS5",
+      "parser" : "DBASSParser",
+      "file" : "https://www.dbass.soton.ac.uk/Dbass5/DownloadCsv",
+      "priority" : 1
+    },
+    {
+      "name" : "EntrezGene",
+      "parser" : "EntrezGeneParser",
+      "file" : "ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz",
+      "priority" : 1
+    },
+    {
+      "name" : "HPA",
+      "parser" : "HPAParser",
+      "file" : "http://www.proteinatlas.org/download/xref.php",
+      "priority" : 1
+    },
+    {
+      "name" : "MGI",
+      "parser" : "MGIParser",
+      "file" : "http://www.informatics.jax.org/downloads/reports/MRK_ENSEMBL.rpt",
+      "priority" : 2
+    },
+    {
+      "name" : "MGI_desc",
+      "parser" : "MGI_Desc_Parser",
+      "file" : "http://www.informatics.jax.org/downloads/reports/MRK_List2.rpt",
+      "priority" : 1
+    },
+    {
+      "name" : "MGI_ccds",
+      "parser" : "MGI_CCDS_Parser",
+      "file" : "http://ftp.ncbi.nlm.nih.gov/pub/CCDS/current_mouse/CCDS.current.txt",
+      "priority" : 2
+    },
+    {
+      "name" : "MIM2GENE",
+      "parser" : "Mim2GeneParser",
+      "file" : "http://ftp.ncbi.nlm.nih.gov/gene/DATA/mim2gene_medgen",
+      "priority" : 3
+    },
+    {
+      "name" : "MIM",
+      "parser" : "MIMParser",
+      "file" : "http://data.omim.org/downloads/s4mpHKpNRgugjDKWuUAJMw/omim.txt.gz",
+      "priority" : 2
+    },
+    {
+      "name" : "RFAM",
+      "parser" : "RFAMParser",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/Rfam/CURRENT/Rfam.seed.gz",
+      "db" : "core",
+      "priority" : 1
+    },
+    {
+      "name" : "RGD",
+      "parser" : "RGDParser",
+      "file" : "https://download.rgd.mcw.edu/pub/data_release/GENES.RAT.txt",
+      "priority" : 2
+    },
+    {
+      "name" : "Reactome",
+      "parser" : "ReactomeParser",
+      "file" : "http://www.reactome.org/download/current/Ensembl2Reactome_All_Levels.txt",
+      "release" : "http://www.reactome.org/ReactomeRESTfulAPI/RESTfulWS/version",
+      "priority" : 1
+    },
+    {
+      "name" : "Reactome",
+      "parser" : "ReactomeParser",
+      "file" : "http://www.reactome.org/download/current/UniProt2Reactome_All_Levels.txt",
+      "release" : "http://www.reactome.org/ReactomeRESTfulAPI/RESTfulWS/version",
+      "priority" : 2
+    },
+    {
+      "name" : "RefSeq_dna",
+      "parser" : "RefSeqGPFFParser",
+      "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/complete/complete*rna.gbff.gz",
+      "method" : "--bestn 5",
+      "query_cutoff" : 90,
+      "target_cutoff" : 90,
+      "release" : "ftp://ftp.ncbi.nih.gov/refseq/release/release-notes/RefSeq-release*.txt",
+      "preparse" : 1,
+      "priority" : 2
+    },
+    {
+      "name" : "RefSeq_peptide",
+      "parser" : "RefSeqGPFFParser",
+      "file" : "ftp://ftp.ncbi.nlm.nih.gov/refseq/release/complete/complete.nonredundant*protein.gpff.gz",
+      "method" : "--bestn 1",
+      "query_cutoff" : 100,
+      "target_cutoff" : 100,
+      "release" : "ftp://ftp.ncbi.nih.gov/refseq/release/release-notes/RefSeq-release*.txt",
+      "preparse" : 1,
+      "priority" : 3
+    },
+    {
+      "name" : "Refseq_import",
+      "parser" : "RefSeqCoordinateParser",
+      "file" : "Database",
+      "db" : "otherfeatures",
+      "priority" : 2
+    },
+    {
+      "name" : "UCSC_hg38",
+      "parser" : "UCSC_human_parser",
+      "file" : "http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz",
+      "release" : "http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/README.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "UCSC_mm10",
+      "parser" : "UCSC_mouse_parser",
+      "file" : "http://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz",
+      "release" : "http://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "Uniprot/SWISSPROT",
+      "parser" : "UniProtParser",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.dat.gz",
+      "method" : "--bestn 1",
+      "query_cutoff" : 100,
+      "target_cutoff" : 100,
+      "preparse" : 1,
+      "release" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "Uniprot/SPTREMBL",
+      "parser" : "UniProtParser",
+      "file" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_trembl.dat.gz",
+      "method" : "--bestn 1",
+      "query_cutoff" : 100,
+      "target_cutoff" : 100,
+      "preparse" : 1,
+      "release" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "VGNC",
+      "parser" : "VGNCParser",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz",
+      "priority" : 1
+    },
+    {
+      "name" : "ZFIN_ID",
+      "parser" : "ZFINParser",
+      "file" : "http://zfin.org/data_transfer/Downloads/refseq.txt",
+      "priority" : 3
+    },
+    {
+      "name" : "ZFIN_ID",
+      "parser" : "ZFINParser",
+      "file" : "http://zfin.org/data_transfer/Downloads/uniprot.txt",
+      "priority" : 2
+    },
+    {
+      "name" : "ZFIN_ID",
+      "parser" : "ZFINParser",
+      "file" : "http://zfin.org/data_transfer/Downloads/aliases.txt",
+      "priority" : 2
+    },
+    {
+      "name" : "ZFIN_ID",
+      "parser" : "ZFINParser",
+      "file" : "http://zfin.org/data_transfer/Downloads/gene_seq.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "ZFIN_desc",
+      "parser" : "ZFINDescParser",
+      "file" : "http://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "cint_jgi_v1",
+      "parser" : "JGI_ProteinParser",
+      "file" : "http://ftp.ensembl.org/pub/misc/cint_jgi/v1/ciona.prot.fasta.gz",
+      "priority" : 1
+    },
+    {
+      "name" : "Xenbase",
+      "parser" : "XenopusJamboreeParser",
+      "file" : "http://ftp.xenbase.org/pub/GenePageReports/GenePageEnsemblModelMapping.txt",
+      "priority" : 1
+    },
+    {
+      "name" : "miRBase",
+      "parser" : "miRBaseParser",
+      "file" : "https://mirbase.org/ftp/CURRENT/miRNA.dat.gz",
+      "method" : "--bestn 1",
+      "query_cutoff" : 90,
+      "target_cutoff" : 90,
+      "priority" : 1
+    },
+    {
+      "name" : "HGNC",
+      "parser" : "HGNCParser",
+      "file" : "https://www.genenames.org/cgi-bin/download?col=gd_hgnc_id&col=gd_app_sym&col=gd_app_name&col=gd_prev_sym&col=gd_aliases&col=gd_pub_eg_id&col=gd_pub_ensembl_id&col=gd_pub_refseq_ids&col=gd_ccds_ids&col=gd_lsdb_links&status=Approved&status_opt=2&where=&order_by=gd_app_sym_sort&format=text&limit=&hgnc_dbtag=on&submit=submit",
+      "db" : "ccds",
+      "priority" : 3
+    }
+]

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -116,6 +116,7 @@
       "query_cutoff" : 90,
       "target_cutoff" : 90,
       "release" : "ftp://ftp.ncbi.nih.gov/refseq/release/release-notes/RefSeq-release*.txt",
+      "preparse" : 1,
       "priority" : 2
     },
     {
@@ -126,6 +127,7 @@
       "query_cutoff" : 90,
       "target_cutoff" : 90,
       "release" : "ftp://ftp.ncbi.nih.gov/refseq/release/release-notes/RefSeq-release*.txt",
+      "preparse" : 1,
       "priority" : 2
     },
     {
@@ -136,6 +138,7 @@
       "query_cutoff" : 100,
       "target_cutoff" : 100,
       "release" : "ftp://ftp.ncbi.nih.gov/refseq/release/release-notes/RefSeq-release*.txt",
+      "preparse" : 1,
       "priority" : 3
     },
     {
@@ -146,6 +149,7 @@
       "query_cutoff" : 100,
       "target_cutoff" : 100,
       "release" : "ftp://ftp.ncbi.nih.gov/refseq/release/release-notes/RefSeq-release*.txt",
+      "preparse" : 1,
       "priority" : 3
     },
     {

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -246,7 +246,7 @@
     {
       "name" : "miRBase",
       "parser" : "miRBaseParser",
-      "file" : "http://mirbase.org/pub/mirbase/CURRENT/miRNA.dat.gz",
+      "file" : "https://mirbase.org/ftp/CURRENT/miRNA.dat.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 90,
       "target_cutoff" : 90,

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -180,6 +180,7 @@
       "method" : "--bestn 1",
       "query_cutoff" : 100,
       "target_cutoff" : 100,
+      "preparse" : 1,
       "release" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
       "priority" : 1
     },
@@ -190,6 +191,7 @@
       "method" : "--bestn 1",
       "query_cutoff" : 100,
       "target_cutoff" : 100,
+      "preparse" : 1,
       "release" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
       "priority" : 1
     },

--- a/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
+++ b/modules/Bio/EnsEMBL/Production/Pipeline/Xrefs/xref_sources.json
@@ -23,7 +23,7 @@
     {
       "name" : "RNACentral",
       "parser" : "ChecksumParser",
-      "file" : "ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/md5/md5.tsv.gz",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/RNAcentral/current_release/md5/md5.tsv.gz",
       "db" : "checksum",
       "priority" : 1
     },
@@ -66,13 +66,13 @@
     {
       "name" : "MGI_ccds",
       "parser" : "MGI_CCDS_Parser",
-      "file" : "ftp://ftp.ncbi.nlm.nih.gov/pub/CCDS/current_mouse/CCDS.current.txt",
+      "file" : "http://ftp.ncbi.nlm.nih.gov/pub/CCDS/current_mouse/CCDS.current.txt",
       "priority" : 2
     },
     {
       "name" : "MIM2GENE",
       "parser" : "Mim2GeneParser",
-      "file" : "ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/mim2gene_medgen",
+      "file" : "http://ftp.ncbi.nlm.nih.gov/gene/DATA/mim2gene_medgen",
       "priority" : 3
     },
     {
@@ -84,14 +84,14 @@
     {
       "name" : "RFAM",
       "parser" : "RFAMParser",
-      "file" : "ftp://ftp.ebi.ac.uk/pub/databases/Rfam/CURRENT/Rfam.seed.gz",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/Rfam/CURRENT/Rfam.seed.gz",
       "db" : "core",
       "priority" : 1
     },
     {
       "name" : "RGD",
       "parser" : "RGDParser",
-      "file" : "ftp://ftp.rgd.mcw.edu/pub/data_release/GENES_RAT.txt",
+      "file" : "https://download.rgd.mcw.edu/pub/data_release/GENES.RAT.txt",
       "priority" : 2
     },
     {
@@ -162,26 +162,26 @@
     {
       "name" : "UCSC_hg38",
       "parser" : "UCSC_human_parser",
-      "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz",
-      "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/README.txt",
+      "file" : "http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/knownGene.txt.gz",
+      "release" : "http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/README.txt",
       "priority" : 1
     },
     {
       "name" : "UCSC_mm10",
       "parser" : "UCSC_mouse_parser",
-      "file" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz",
-      "release" : "ftp://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt",
+      "file" : "http://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/knownGene.txt.gz",
+      "release" : "http://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/README.txt",
       "priority" : 1
     },
     {
       "name" : "Uniprot/SWISSPROT",
       "parser" : "UniProtParser",
-      "file" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.dat.gz",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/uniprot_sprot.dat.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 100,
       "target_cutoff" : 100,
       "preparse" : 1,
-      "release" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
+      "release" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
       "priority" : 1
     },
     {
@@ -192,13 +192,13 @@
       "query_cutoff" : 100,
       "target_cutoff" : 100,
       "preparse" : 1,
-      "release" : "ftp://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
+      "release" : "http://ftp.ebi.ac.uk/pub/databases/uniprot/knowledgebase/reldate.txt",
       "priority" : 1
     },
     {
       "name" : "VGNC",
       "parser" : "VGNCParser",
-      "file" : "ftp://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz",
+      "file" : "http://ftp.ebi.ac.uk/pub/databases/genenames/vgnc/tsv/vgnc_gene_set_All.txt.gz",
       "priority" : 1
     },
     {
@@ -228,25 +228,25 @@
     {
       "name" : "ZFIN_desc",
       "parser" : "ZFINDescParser",
-      "file" : "ftp://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
+      "file" : "http://zfin.org/pub/transfer/MEOW/zfin_genes.txt",
       "priority" : 1
     },
     {
       "name" : "cint_jgi_v1",
       "parser" : "JGI_ProteinParser",
-      "file" : "ftp://ftp.ensembl.org/pub/misc/cint_jgi/v1/ciona.prot.fasta.gz",
+      "file" : "http://ftp.ensembl.org/pub/misc/cint_jgi/v1/ciona.prot.fasta.gz",
       "priority" : 1
     },
     {
       "name" : "Xenbase",
       "parser" : "XenopusJamboreeParser",
-      "file" : "ftp://ftp.xenbase.org/pub/GenePageReports/GenePageEnsemblModelMapping.txt",
+      "file" : "http://ftp.xenbase.org/pub/GenePageReports/GenePageEnsemblModelMapping.txt",
       "priority" : 1
     },
     {
       "name" : "miRBase",
       "parser" : "miRBaseParser",
-      "file" : "ftp://mirbase.org/pub/mirbase/CURRENT/miRNA.dat.gz",
+      "file" : "http://mirbase.org/pub/mirbase/CURRENT/miRNA.dat.gz",
       "method" : "--bestn 1",
       "query_cutoff" : 90,
       "target_cutoff" : 90,


### PR DESCRIPTION
**Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion**

## Requirements

- Filling out the template is required. 
- Review the [contributing guidelines](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#why-could-my-pull-request-be-rejected) for this repository; remember in particular:
    - do not modify code without testing for regression
    - provide simple unit tests to test the changes
    - if you change the schema you must patch the test databases as well, see [Updating the schema](https://github.com/Ensembl/ensembl/blob/master/CONTRIBUTING.md#updating-the-schema)
    - the PR must not fail unit testing

## Description

Add pre-parse analyses for RefSeq and UniProt data
This creates a central databases of all xrefs for those sources, which can be used to extract species-specific data
Some sources' download links have been updated from ftp to http, as FTP support is dropping
Also split UniProt input files in smaller chunks while cleaning, to improve pre-parsing time

## Use case

Pre-parsing means the whole UniProt data is read only once, then stored in the database
When running the xref pipeline for a species, the appropriate data can be extracted from the central xref database directly via taxon id, without having to process several large files

## Benefits

Parsing per species is improved
Data can be pre-parsed ahead of time, improving performance at release time

## Possible Drawbacks

The resulting central xref database is quite big and there can be some performance issues
The process of pre-parsing is also takes longer than running parsing for a single species, so it is only worth it when the data is re-used for multiple species

## Testing

- [ ] Have you added/modified unit tests to test the changes?
- [ ] If so, do the tests pass?
- [ ] Have you run the entire test suite and no regression was detected?
- [ ] TravisCI passed on your branch

Dependencies
------------

> If applicable, define what code dependencies were added and/or updated.
